### PR TITLE
Add archive map for what files are expected within a given archive.

### DIFF
--- a/.idea/AssessmentModel-JsonSchema.iml
+++ b/.idea/AssessmentModel-JsonSchema.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -7,125 +7,114 @@
           <value>
             <SchemaInfo>
               <option name="name" value="AnswerType" />
-              <option name="relativePathToSchema" value="schemas/AnswerType.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
+              <option name="relativePathToSchema" value="schemas/v1/AnswerType.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="ArchiveMap">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="ArchiveMap" />
+              <option name="relativePathToSchema" value="schemas/v1/ArchiveMap.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
               <option name="patterns">
                 <list>
                   <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/AnswerType" />
-                    <option name="mappingKind" value="Directory" />
+                    <option name="path" value="archive-map.json" />
                   </Item>
                 </list>
               </option>
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="AsyncActionConfiguration">
+        <entry key="AssessmentTaskObject">
           <value>
             <SchemaInfo>
-              <option name="name" value="AsyncActionConfiguration" />
-              <option name="relativePathToSchema" value="schemas/AsyncActionConfiguration.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/AsyncActionConfiguration" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="AssessmentTaskObject" />
+              <option name="relativePathToSchema" value="schemas/v1/AssessmentTaskObject.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="ButtonActionInfo">
+        <entry key="AudioLevelRecord">
           <value>
             <SchemaInfo>
-              <option name="name" value="ButtonActionInfo" />
-              <option name="relativePathToSchema" value="schemas/ButtonActionInfo.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/ButtonActionInfo" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="AudioLevelRecord" />
+              <option name="relativePathToSchema" value="schemas/v1/AudioLevelRecord.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="ColorMappingThemeElement">
+        <entry key="DistanceRecord">
           <value>
             <SchemaInfo>
-              <option name="name" value="ColorMappingThemeElement" />
-              <option name="relativePathToSchema" value="schemas/ColorMappingThemeElement.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/ColorMappingThemeElement" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="DistanceRecord" />
+              <option name="relativePathToSchema" value="schemas/v1/DistanceRecord.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="ImageInfo">
+        <entry key="MCTTaskObject">
           <value>
             <SchemaInfo>
-              <option name="name" value="ImageInfo" />
-              <option name="relativePathToSchema" value="schemas/ImageInfo.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/ImageInfo" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="MCTTaskObject" />
+              <option name="relativePathToSchema" value="schemas/v1/MCTTaskObject.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="InputItem">
+        <entry key="MotionRecord">
           <value>
             <SchemaInfo>
-              <option name="name" value="InputItem" />
-              <option name="relativePathToSchema" value="schemas/InputItem.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/InputItem" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="MotionRecord" />
+              <option name="relativePathToSchema" value="schemas/v1/MotionRecord.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="Result">
+        <entry key="ResultData">
           <value>
             <SchemaInfo>
-              <option name="name" value="Result" />
-              <option name="relativePathToSchema" value="schemas/Result.json" />
-              <option name="schemaVersion" value="JSON schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="directory" value="true" />
-                    <option name="path" value="examples/Result" />
-                    <option name="mappingKind" value="Directory" />
-                  </Item>
-                </list>
-              </option>
+              <option name="name" value="ResultData" />
+              <option name="relativePathToSchema" value="schemas/v1/ResultData.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="TappingResultObject">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="TappingResultObject" />
+              <option name="relativePathToSchema" value="schemas/v1/TappingResultObject.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="TaskMetadata">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="TaskMetadata" />
+              <option name="relativePathToSchema" value="schemas/v1/TaskMetadata.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="TaskResultObject">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="TaskResultObject" />
+              <option name="relativePathToSchema" value="schemas/v1/TaskResultObject.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+            </SchemaInfo>
+          </value>
+        </entry>
+        <entry key="WeatherResult">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="WeatherResult" />
+              <option name="relativePathToSchema" value="schemas/v1/WeatherResult.json" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
             </SchemaInfo>
           </value>
         </entry>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/AssessmentModel-JsonSchema.iml" filepath="$PROJECT_DIR$/.idea/AssessmentModel-JsonSchema.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/archive-map.json
+++ b/archive-map.json
@@ -1,0 +1,237 @@
+{
+  "$id": "https://sage-bionetworks.github.io/mobile-client-json/archive-map.json",
+  "$schema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/ArchiveMap.json",
+  "allOf": [
+    {
+      "filename": "metadata.json",
+      "contentType": "application/json",
+      "description": "Metadata associated with this archive including a file manifest and version information.",
+      "isRequired": true,
+      "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/TaskMetadata.json"
+    },
+    {
+      "filename": "taskResult.json",
+      "contentType": "application/json",
+      "description": "The polymorphism serialized result of running an assessment. This structure includes all the step results in the chronological order in which they were presented as well as asynchronous results that may be recorded across multiple steps.",
+      "isRequired": false,
+      "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/TaskResultObject.json"
+    },
+    {
+      "filename": "answers.json",
+      "contentType": "application/json",
+      "description": "A file used by Exporter 2.0 to export Bridge 1.0 surveys to synapse.",
+      "deprecated": true
+    },
+    {
+      "filename": "info.json",
+      "contentType": "application/json",
+      "description": "A file used by Exporter 2.0 to export data to synapse.",
+      "deprecated": true
+    }
+  ],
+  "assessments" : [
+    {
+      "assessmentIdentifier" : "spelling",
+      "assessmentRevision": 5,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "MTB Spelling Form 1",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "fnamea",
+      "assessmentRevision": 5,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "FNAME Learning Form 1",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "fnameb",
+      "assessmentRevision": 5,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "FNAME Test Form 1",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "vocabulary",
+      "assessmentRevision": 5,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "Vocabulary Form 1",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "flanker",
+      "assessmentRevision": 5,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "Flanker Inhibitory Control",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "psm",
+      "assessmentRevision": 6,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "Picture Sequence MemoryV1",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "memory-for-sequences",
+      "assessmentRevision": 7,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "MFS pilot 2",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "dccs",
+      "assessmentRevision": 6,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "Dimensional Change Card Sort",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier" : "number-match",
+      "assessmentRevision": 4,
+      "organization": "Northwestern (MTB)",
+      "taskIdentifier": "Number Match",
+      "versionString": "1.2.0",
+      "files": [
+        {
+          "filename": "taskData.json",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+        }
+      ]
+    }
+  ],
+  "apps": [
+    {
+      "appId": "mobile-toolbox",
+      "iOS": 0,
+      "android": 0,
+      "allOf": [
+        {
+          "filename": "motion.json",
+          "description": "Motion sensor data recorded while running the assessment.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        },
+        {
+          "filename": "weather.json",
+          "description": "The most recent weather conditions for the participant's location when the assessment is started.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/WeatherResult.json"
+        },
+        {
+          "filename": "microphone_levels.json",
+          "description": "The microphone levels recorded while running the assessment.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/AudioLevelRecord.json"
+        }
+      ],
+      "assessments": [
+        {
+          "assessmentIdentifier": "spelling",
+          "assessmentRevision": 5
+        },
+        {
+          "assessmentIdentifier" : "fnamea",
+          "assessmentRevision": 5
+        },
+        {
+          "assessmentIdentifier" : "fnameb",
+          "assessmentRevision": 5
+        },
+        {
+          "assessmentIdentifier" : "vocabulary",
+          "assessmentRevision": 5
+        },
+        {
+          "assessmentIdentifier" : "flanker",
+          "assessmentRevision": 5
+        },
+        {
+          "assessmentIdentifier" : "psm",
+          "assessmentRevision": 6
+        },
+        {
+          "assessmentIdentifier" : "memory-for-sequences",
+          "assessmentRevision": 7
+        },
+        {
+          "assessmentIdentifier" : "dccs",
+          "assessmentRevision": 6
+        },
+        {
+          "assessmentIdentifier" : "number-match",
+          "assessmentRevision": 4
+        }
+      ]
+    }
+  ]
+}

--- a/archive-map.json
+++ b/archive-map.json
@@ -41,7 +41,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -56,7 +56,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -71,7 +71,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -86,7 +86,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -101,7 +101,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -116,7 +116,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -131,7 +131,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -146,7 +146,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },
@@ -161,7 +161,7 @@
           "filename": "taskData.json",
           "contentType": "application/json",
           "isRequired": true,
-          "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
+          "jsonSchema": "https://raw.githubusercontent.com/MobileToolbox/MTBfx/937cdd1bf3b09815e97b53632c58208a14255b34/JSONschema/taskData_combinedSchema.json"
         }
       ]
     },

--- a/archive-map.json
+++ b/archive-map.json
@@ -164,6 +164,97 @@
           "jsonSchema": "https://github.com/MobileToolbox/MTBfx/blob/master/JSONschema/taskData_combinedSchema.json"
         }
       ]
+    },
+    {
+      "assessmentIdentifier": "walk-and-balance",
+      "assessmentRevision": 1,
+      "organization": "Sage Bionetworks",
+      "taskIdentifier": "WalkAndBalance",
+      "versionString": "2.0.0",
+      "files": [
+        {
+          "filename": "walk_motion.json",
+          "description": "Motion sensor data recorded while the participant is walking.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        },
+        {
+          "filename": "balance_motion.json",
+          "description": "Motion sensor data recorded while the participant is standing still.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier": "tremor",
+      "assessmentRevision": 1,
+      "organization": "Sage Bionetworks",
+      "taskIdentifier": "Tremor",
+      "versionString": "2.0.0",
+      "files": [
+        {
+          "filename": "left_motion.json",
+          "description": "Motion sensor data recorded while the participant is holding the phone in their left hand.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        },
+        {
+          "filename": "right_motion.json",
+          "description": "Motion sensor data recorded while the participant is holding the phone in their right hand.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        }
+      ]
+    },
+    {
+      "assessmentIdentifier": "finger-tapping",
+      "assessmentRevision": 1,
+      "organization": "Sage Bionetworks",
+      "taskIdentifier": "Tapping",
+      "versionString": "2.0.0",
+      "files": [
+        {
+          "filename": "left_motion.json",
+          "description": "Motion sensor data recorded while the participant is tapping the phone with their left hand.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        },
+        {
+          "filename": "right_motion.json",
+          "description": "Motion sensor data recorded while the participant is tapping the phone with their right hand.",
+          "contentType": "application/json",
+          "isRequired": false,
+          "$comment": "This is marked as 'not required' because simulator testing will not include this file.",
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/MotionRecord.json"
+        },
+        {
+          "filename": "right_tapping",
+          "$comment": "This filename does not include the '.json' file extension because of file naming conventions required by Exporter 1.0.",
+          "description": "The tapping test results for the participant's right hand.",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/TappingResultObject.json"
+        },
+        {
+          "filename": "left_tapping",
+          "$comment": "This filename does not include the '.json' file extension because of file naming conventions required by Exporter 1.0.",
+          "description": "The tapping test results for the participant's left hand.",
+          "contentType": "application/json",
+          "isRequired": true,
+          "jsonSchema": "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/TappingResultObject.json"
+        }
+      ]
     }
   ],
   "apps": [

--- a/schemas/v1/ArchiveMap.json
+++ b/schemas/v1/ArchiveMap.json
@@ -90,6 +90,9 @@
           "type" : "boolean",
           "description" : "Whether or not the file is deprecated and included for reverse-compatibility to older services and/or applications.",
           "default" : false
+        },
+        "$comment" : {
+          "type": "string"
         }
       },
       "required" : [

--- a/schemas/v1/ArchiveMap.json
+++ b/schemas/v1/ArchiveMap.json
@@ -1,0 +1,178 @@
+{
+  "$id" : "https://sage-bionetworks.github.io/mobile-client-json/schemas/v1/ArchiveMap.json",
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "title" : "ArchiveMap",
+  "definitions" : {
+    "AssessmentIdentifier" : {
+      "$id" : "#AssessmentIdentifier",
+      "type" : "object",
+      "properties" : {
+        "assessmentIdentifier": {
+          "type": "string",
+          "description": "The assessment identifier defined within the Bridge namespace for the assessment. This identifier will map to the participant timeline."
+        },
+        "assessmentRevision": {
+          "type": "integer",
+          "description": "The min assessment revision as defined within the Bridge namespace for this archive manifest."
+        }
+      },
+      "required" : [
+        "assessmentIdentifier",
+        "assessmentRevision"
+      ]
+    },
+    "AssessmentArchive" : {
+      "$id" : "#AssessmentArchive",
+      "type" : "object",
+      "title" : "AssessmentArchive",
+      "description" : "The mappings for a given assessment archive.",
+      "allOf": [
+        {
+          "$ref": "#AssessmentIdentifier"
+        }
+      ],
+      "additionalProperties": false,
+      "properties" : {
+        "organization" : {
+          "type" : "string",
+          "description" : "The name or description of the assessment developer's organization. This is included for readability, is not necessarily the official organization name, and should not be used for searches or identifying the assessment."
+        },
+        "taskIdentifier" : {
+          "type" : "string",
+          "description" : "The identifier assigned by the assessment developer. This identifier is unique only within the developer's framework namespace."
+        },
+        "versionString" : {
+          "type" : "string",
+          "description" : "The min assessment version as defined by the assessment developer for this archive manifest."
+        },
+        "files" : {
+          "type" : "array",
+          "description": "The list of the files included in the assessment archive.",
+          "items": {
+            "$ref": "#FileInfo"
+          }
+        }
+      }
+    },
+    "FileInfo" : {
+      "$id" : "#FileInfo",
+      "type" : "object",
+      "title" : "FileInfo",
+      "description" : "Information about a given file within the archive.",
+      "additionalProperties": false,
+      "properties" : {
+        "filename" : {
+          "type" : "string",
+          "description" : "The filename of the archive object. This should be unique within the manifest.",
+          "format" : "uri-relative"
+        },
+        "description" : {
+          "type": "string",
+          "description": "Description of the file content."
+        },
+        "contentType" : {
+          "type" : "string",
+          "description" : "The content type of the file.",
+          "default": "application/json"
+        },
+        "jsonSchema" : {
+          "type" : "string",
+          "description" : "The uri for the json schema if the content type is 'application/json'.",
+          "format" : "uri"
+        },
+        "isRequired" : {
+          "type" : "boolean",
+          "description" : "Whether or not the file is required.",
+          "default" : false
+        },
+        "deprecated" : {
+          "type" : "boolean",
+          "description" : "Whether or not the file is deprecated and included for reverse-compatibility to older services and/or applications.",
+          "default" : false
+        }
+      },
+      "required" : [
+        "filename"
+      ]
+    },
+    "AppInfo" : {
+      "$id" : "#AppInfo",
+      "type" : "object",
+      "title" : "AppInfo",
+      "description" : "Bridge App Information",
+      "additionalProperties": false,
+      "properties" : {
+        "appId" : {
+          "type" : "string",
+          "description" : "Bridge 'APP ID' for the application that is sending the data."
+        },
+        "iOS" : {
+          "type" : "integer",
+          "description" : "The min version sent to Bridge to identify the version of the iOS application.",
+          "default" : 0
+        },
+        "android" : {
+          "type" : "integer",
+          "description" : "The min version sent to Bridge to identify the version of the Android application.",
+          "default" : 0
+        },
+        "assessments" : {
+          "type" : "array",
+          "description": "The list of assessments supported by this application.",
+          "items": {
+            "$ref" : "#AssessmentIdentifier"
+          }
+        },
+        "allOf" : {
+          "type": "array",
+          "description": "A list of files that may be included in any assessment archive for *this* application. These files can be associated with the assessments within this application but are *not* inclusive to a different application that hosts the same assessment.",
+          "items": {
+            "$ref": "#FileInfo"
+          }
+        }
+      },
+      "required" : [
+        "appId",
+        "assessments"
+      ]
+    }
+  },
+  "properties": {
+    "$id" : {
+      "type": "string",
+      "format": "uri"
+    },
+    "$schema" : {
+      "type": "string",
+      "format": "uri"
+    },
+    "allOf" : {
+      "type": "array",
+      "description": "A list of files that are included by default in all archives across all applications.",
+      "items": {
+        "$ref": "#FileInfo"
+      }
+    },
+    "assessments" : {
+      "type": "array",
+      "description": "A list of assessment archives uniquely indexed by `assessmentIdentifier` and `assessmentRevision`.",
+      "items": {
+        "$ref": "#AssessmentArchive"
+      }
+    },
+    "apps" : {
+      "type": "array",
+      "description": "A list of apps uniquely indexed by identifier and version.",
+      "items": {
+        "$ref": "#AppInfo"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "$id",
+    "$schema",
+    "assessments"
+  ]
+}


### PR DESCRIPTION
The goal here is to unblock Tess's team with an open source URL that they can use to read in the mappings of assessment to json schema. 

Note: The schema for the archive-map.json file is split into three sections: 

- "allOf" includes files that may be present in the archive for any assessment archive bundled using Sage mobile client frameworks. 
- "assessments" includes the mapping to the Bridge 2.0 assessment identifier and revision (Bridge uses integers for versioning and does not support semantic versioning used elsewhere). The files included with the assessment should be included with that assessment for *all* applications. 
- "apps" includes the mapping of archive files specific to *that* application. For example, all assessments within MobileToolbox can optionally be run with background recorders for ambient noise levels, motion sensors, and weather whereas mPower 2.0 would include medication tracking. (I did not add mPower 2.0 since not all the files included by mPower 2.0 have a json schema definition.) And it includes a list of "unique identifiers (assessmentIdentifier+assessmentRevision)" for each assessment it supports.
