### PR TITLE
Update generator, examples, and fix the WeatherResult schema

### DIFF
--- a/examples/v2/AnswerType/AnswerTypeArray_0.json
+++ b/examples/v2/AnswerType/AnswerTypeArray_0.json
@@ -1,1 +1,4 @@
-{"type":"array","baseType":"number"}
+{
+  "baseType" : "number",
+  "type" : "array"
+}

--- a/examples/v2/AnswerType/AnswerTypeArray_1.json
+++ b/examples/v2/AnswerType/AnswerTypeArray_1.json
@@ -1,1 +1,4 @@
-{"type":"array","baseType":"integer"}
+{
+  "baseType" : "integer",
+  "type" : "array"
+}

--- a/examples/v2/AnswerType/AnswerTypeArray_2.json
+++ b/examples/v2/AnswerType/AnswerTypeArray_2.json
@@ -1,1 +1,4 @@
-{"type":"array","baseType":"string"}
+{
+  "baseType" : "string",
+  "type" : "array"
+}

--- a/examples/v2/AnswerType/AnswerTypeBoolean_0.json
+++ b/examples/v2/AnswerType/AnswerTypeBoolean_0.json
@@ -1,1 +1,3 @@
-{"type":"boolean"}
+{
+  "type" : "boolean"
+}

--- a/examples/v2/AnswerType/AnswerTypeDateTime_0.json
+++ b/examples/v2/AnswerType/AnswerTypeDateTime_0.json
@@ -1,1 +1,4 @@
-{"codingFormat":"yyyy-MM","type":"date-time"}
+{
+  "codingFormat" : "yyyy-MM",
+  "type" : "date-time"
+}

--- a/examples/v2/AnswerType/AnswerTypeDateTime_1.json
+++ b/examples/v2/AnswerType/AnswerTypeDateTime_1.json
@@ -1,1 +1,4 @@
-{"codingFormat":"HH:mm","type":"date-time"}
+{
+  "codingFormat" : "HH:mm",
+  "type" : "date-time"
+}

--- a/examples/v2/AnswerType/AnswerTypeDateTime_2.json
+++ b/examples/v2/AnswerType/AnswerTypeDateTime_2.json
@@ -1,1 +1,4 @@
-{"type":"date-time","codingFormat":"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"}
+{
+  "codingFormat" : "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+  "type" : "date-time"
+}

--- a/examples/v2/AnswerType/AnswerTypeDuration_0.json
+++ b/examples/v2/AnswerType/AnswerTypeDuration_0.json
@@ -1,1 +1,8 @@
-{"type":"duration","displayUnits":["hour","minute"],"significantDigits":0}
+{
+  "displayUnits" : [
+    "hour",
+    "minute"
+  ],
+  "significantDigits" : 0,
+  "type" : "duration"
+}

--- a/examples/v2/AnswerType/AnswerTypeInteger_0.json
+++ b/examples/v2/AnswerType/AnswerTypeInteger_0.json
@@ -1,1 +1,3 @@
-{"type":"integer"}
+{
+  "type" : "integer"
+}

--- a/examples/v2/AnswerType/AnswerTypeMeasurement_0.json
+++ b/examples/v2/AnswerType/AnswerTypeMeasurement_0.json
@@ -1,1 +1,4 @@
-{"type":"measurement","unit":"cm"}
+{
+  "type" : "measurement",
+  "unit" : "cm"
+}

--- a/examples/v2/AnswerType/AnswerTypeNumber_0.json
+++ b/examples/v2/AnswerType/AnswerTypeNumber_0.json
@@ -1,1 +1,3 @@
-{"type":"number"}
+{
+  "type" : "number"
+}

--- a/examples/v2/AnswerType/AnswerTypeObject_0.json
+++ b/examples/v2/AnswerType/AnswerTypeObject_0.json
@@ -1,1 +1,3 @@
-{"type":"object"}
+{
+  "type" : "object"
+}

--- a/examples/v2/AnswerType/AnswerTypeString_0.json
+++ b/examples/v2/AnswerType/AnswerTypeString_0.json
@@ -1,1 +1,3 @@
-{"type":"string"}
+{
+  "type" : "string"
+}

--- a/examples/v2/AnswerType/AnswerTypeTime_0.json
+++ b/examples/v2/AnswerType/AnswerTypeTime_0.json
@@ -1,1 +1,4 @@
-{"type":"time","codingFormat":"HH:mm:ss.SSS"}
+{
+  "codingFormat" : "HH:mm:ss.SSS",
+  "type" : "time"
+}

--- a/examples/v2/AsyncActionConfiguration/AudioRecorderConfigurationObject_0.json
+++ b/examples/v2/AsyncActionConfiguration/AudioRecorderConfigurationObject_0.json
@@ -1,1 +1,8 @@
-{"requiresBackgroundAudio":true,"saveAudioFile":true,"startStepIdentifier":"countdown","type":"microphone","identifier":"microphone","stopStepIdentifier":"rest"}
+{
+  "identifier" : "microphone",
+  "requiresBackgroundAudio" : true,
+  "saveAudioFile" : true,
+  "startStepIdentifier" : "countdown",
+  "stopStepIdentifier" : "rest",
+  "type" : "microphone"
+}

--- a/examples/v2/AsyncActionConfiguration/DistanceRecorderConfigurationObject_0.json
+++ b/examples/v2/AsyncActionConfiguration/DistanceRecorderConfigurationObject_0.json
@@ -1,1 +1,7 @@
-{"stopStepIdentifier":"rest","identifier":"distance","startStepIdentifier":"countdown","motionStepIdentifier":"run","type":"distance"}
+{
+  "identifier" : "distance",
+  "motionStepIdentifier" : "run",
+  "startStepIdentifier" : "countdown",
+  "stopStepIdentifier" : "rest",
+  "type" : "distance"
+}

--- a/examples/v2/AsyncActionConfiguration/ExampleAsyncActionConfiguration_0.json
+++ b/examples/v2/AsyncActionConfiguration/ExampleAsyncActionConfiguration_0.json
@@ -1,1 +1,0 @@
-{"type":"example"}

--- a/examples/v2/AsyncActionConfiguration/MotionRecorderConfigurationObject_0.json
+++ b/examples/v2/AsyncActionConfiguration/MotionRecorderConfigurationObject_0.json
@@ -1,1 +1,5 @@
-{"type":"motion","identifier":"exampleA","requiresBackgroundAudio":false}
+{
+  "identifier" : "exampleA",
+  "requiresBackgroundAudio" : false,
+  "type" : "motion"
+}

--- a/examples/v2/AsyncActionConfiguration/MotionRecorderConfigurationObject_1.json
+++ b/examples/v2/AsyncActionConfiguration/MotionRecorderConfigurationObject_1.json
@@ -1,1 +1,12 @@
-{"usesCSVEncoding":true,"type":"motion","identifier":"exampleB","frequency":200,"shouldDeletePrevious":false,"requiresBackgroundAudio":true,"recorderTypes":["gyro","gravity"]}
+{
+  "frequency" : 200,
+  "identifier" : "exampleB",
+  "recorderTypes" : [
+    "gyro",
+    "gravity"
+  ],
+  "requiresBackgroundAudio" : true,
+  "shouldDeletePrevious" : false,
+  "type" : "motion",
+  "usesCSVEncoding" : true
+}

--- a/examples/v2/AsyncActionConfiguration/WeatherConfigurationObject_0.json
+++ b/examples/v2/AsyncActionConfiguration/WeatherConfigurationObject_0.json
@@ -1,1 +1,17 @@
-{"services":[{"identifier":"weather","key":"ABCD","provider":"openWeather"},{"key":"ABCD","identifier":"airQuality","provider":"airNow"}],"identifier":"weather","startStepIdentifier":"countdown","type":"weather"}
+{
+  "identifier" : "weather",
+  "services" : [
+    {
+      "identifier" : "weather",
+      "key" : "ABCD",
+      "provider" : "openWeather"
+    },
+    {
+      "identifier" : "airQuality",
+      "key" : "ABCD",
+      "provider" : "airNow"
+    }
+  ],
+  "startStepIdentifier" : "countdown",
+  "type" : "weather"
+}

--- a/examples/v2/ButtonActionInfo/ButtonActionInfoObject_0.json
+++ b/examples/v2/ButtonActionInfo/ButtonActionInfoObject_0.json
@@ -1,1 +1,4 @@
-{"buttonTitle":"Go, Dogs! Go","type":"default"}
+{
+  "buttonTitle" : "Go, Dogs! Go",
+  "type" : "default"
+}

--- a/examples/v2/ButtonActionInfo/ButtonActionInfoObject_1.json
+++ b/examples/v2/ButtonActionInfo/ButtonActionInfoObject_1.json
@@ -1,1 +1,5 @@
-{"iconName":"closeX","bundleIdentifier":"org.example.SharedResources","type":"default"}
+{
+  "bundleIdentifier" : "org.example.SharedResources",
+  "iconName" : "closeX",
+  "type" : "default"
+}

--- a/examples/v2/ButtonActionInfo/NavigationButtonActionInfoObject_0.json
+++ b/examples/v2/ButtonActionInfo/NavigationButtonActionInfoObject_0.json
@@ -1,1 +1,5 @@
-{"skipToIdentifier":"foo","type":"navigation","buttonTitle":"Go, Dogs! Go"}
+{
+  "buttonTitle" : "Go, Dogs! Go",
+  "skipToIdentifier" : "foo",
+  "type" : "navigation"
+}

--- a/examples/v2/ButtonActionInfo/NavigationButtonActionInfoObject_1.json
+++ b/examples/v2/ButtonActionInfo/NavigationButtonActionInfoObject_1.json
@@ -1,1 +1,6 @@
-{"iconName":"closeX","bundleIdentifier":"org.example.SharedResources","skipToIdentifier":"foo","type":"navigation"}
+{
+  "bundleIdentifier" : "org.example.SharedResources",
+  "iconName" : "closeX",
+  "skipToIdentifier" : "foo",
+  "type" : "navigation"
+}

--- a/examples/v2/ImageInfo/AnimatedImage_0.json
+++ b/examples/v2/ImageInfo/AnimatedImage_0.json
@@ -1,1 +1,10 @@
-{"imageNames":["blueDog1","blueDog2","blueDog3"],"type":"animated","animationDuration":2,"animationRepeatCount":0}
+{
+  "animationDuration" : 2,
+  "animationRepeatCount" : 0,
+  "imageNames" : [
+    "blueDog1",
+    "blueDog2",
+    "blueDog3"
+  ],
+  "type" : "animated"
+}

--- a/examples/v2/ImageInfo/AnimatedImage_1.json
+++ b/examples/v2/ImageInfo/AnimatedImage_1.json
@@ -1,1 +1,11 @@
-{"animationDuration":2,"animationRepeatCount":0,"bundleIdentifier":"org.example.SharedResources","imageNames":["redCat1","redCat2","redCat3"],"type":"animated"}
+{
+  "animationDuration" : 2,
+  "animationRepeatCount" : 0,
+  "bundleIdentifier" : "org.example.SharedResources",
+  "imageNames" : [
+    "redCat1",
+    "redCat2",
+    "redCat3"
+  ],
+  "type" : "animated"
+}

--- a/examples/v2/ImageInfo/FetchableImage_0.json
+++ b/examples/v2/ImageInfo/FetchableImage_0.json
@@ -1,1 +1,4 @@
-{"imageName":"blueDog","type":"fetchable"}
+{
+  "imageName" : "blueDog",
+  "type" : "fetchable"
+}

--- a/examples/v2/ImageInfo/FetchableImage_1.json
+++ b/examples/v2/ImageInfo/FetchableImage_1.json
@@ -1,1 +1,6 @@
-{"packageName":"org.example.sharedresources","bundleIdentifier":"org.example.SharedResources","type":"fetchable","imageName":"redCat.jpeg"}
+{
+  "bundleIdentifier" : "org.example.SharedResources",
+  "imageName" : "redCat.jpeg",
+  "packageName" : "org.example.sharedresources",
+  "type" : "fetchable"
+}

--- a/examples/v2/ImageInfo/SageResourceImage_0.json
+++ b/examples/v2/ImageInfo/SageResourceImage_0.json
@@ -1,1 +1,4 @@
-{"imageName":"survey","type":"sageResource"}
+{
+  "imageName" : "default",
+  "type" : "sageResource"
+}

--- a/examples/v2/Node/ChoiceQuestionStepObject_0.json
+++ b/examples/v2/Node/ChoiceQuestionStepObject_0.json
@@ -1,1 +1,20 @@
-{"choices":[{"text":"ba","value":"ba"},{"value":"la","text":"la"},{"text":"lala","value":"lala"}],"identifier":"foo","type":"choiceQuestion","singleChoice":true,"baseType":"string"}
+{
+  "baseType" : "string",
+  "choices" : [
+    {
+      "text" : "ba",
+      "value" : "ba"
+    },
+    {
+      "text" : "la",
+      "value" : "la"
+    },
+    {
+      "text" : "lala",
+      "value" : "lala"
+    }
+  ],
+  "identifier" : "foo",
+  "singleChoice" : true,
+  "type" : "choiceQuestion"
+}

--- a/examples/v2/Node/CompletionStepObject_0.json
+++ b/examples/v2/Node/CompletionStepObject_0.json
@@ -1,1 +1,4 @@
-{"identifier":"example","type":"completion"}
+{
+  "identifier" : "example",
+  "type" : "completion"
+}

--- a/examples/v2/Node/CountdownStepObject_0.json
+++ b/examples/v2/Node/CountdownStepObject_0.json
@@ -1,0 +1,5 @@
+{
+  "duration" : 3,
+  "identifier" : "example",
+  "type" : "countdown"
+}

--- a/examples/v2/Node/InstructionStepObject_0.json
+++ b/examples/v2/Node/InstructionStepObject_0.json
@@ -1,1 +1,4 @@
-{"type":"instruction","identifier":"example"}
+{
+  "identifier" : "example",
+  "type" : "instruction"
+}

--- a/examples/v2/Node/OverviewStepObject_0.json
+++ b/examples/v2/Node/OverviewStepObject_0.json
@@ -1,1 +1,4 @@
-{"identifier":"example","type":"overview"}
+{
+  "identifier" : "example",
+  "type" : "overview"
+}

--- a/examples/v2/Node/PermissionStepObject_0.json
+++ b/examples/v2/Node/PermissionStepObject_0.json
@@ -1,1 +1,5 @@
-{"type":"permission","permissionType":"motion","identifier":"example"}
+{
+  "identifier" : "example",
+  "permissionType" : "motion",
+  "type" : "permission"
+}

--- a/examples/v2/Node/SectionObject_0.json
+++ b/examples/v2/Node/SectionObject_0.json
@@ -1,1 +1,14 @@
-{"identifier":"section","steps":[{"title":"What is your favorite color","identifier":"favoriteColor","type":"simpleQuestion","inputItem":{"type":"string"}}],"type":"section"}
+{
+  "identifier" : "section",
+  "steps" : [
+    {
+      "identifier" : "favoriteColor",
+      "inputItem" : {
+        "type" : "string"
+      },
+      "title" : "What is your favorite color",
+      "type" : "simpleQuestion"
+    }
+  ],
+  "type" : "section"
+}

--- a/examples/v2/Node/SimpleQuestionStepObject_0.json
+++ b/examples/v2/Node/SimpleQuestionStepObject_0.json
@@ -1,1 +1,7 @@
-{"inputItem":{"type":"string"},"type":"simpleQuestion","identifier":"foo"}
+{
+  "identifier" : "foo",
+  "inputItem" : {
+    "type" : "string"
+  },
+  "type" : "simpleQuestion"
+}

--- a/examples/v2/ResultData/AnswerResultObject_0.json
+++ b/examples/v2/ResultData/AnswerResultObject_0.json
@@ -1,1 +1,10 @@
-{"type":"answer","identifier":"question1","startDate":"2017-10-16T22:28:09.000-07:00","value":true,"answerType":{"type":"boolean"},"endDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "answerType" : {
+    "type" : "boolean"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question1",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : true
+}

--- a/examples/v2/ResultData/AnswerResultObject_1.json
+++ b/examples/v2/ResultData/AnswerResultObject_1.json
@@ -1,1 +1,10 @@
-{"answerType":{"type":"integer"},"startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00","value":42,"type":"answer","identifier":"question2"}
+{
+  "answerType" : {
+    "type" : "integer"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question2",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : 42
+}

--- a/examples/v2/ResultData/AnswerResultObject_10.json
+++ b/examples/v2/ResultData/AnswerResultObject_10.json
@@ -1,1 +1,11 @@
-{"answerType":{"type":"date-time","codingFormat":"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"},"type":"answer","value":"2017-10-16T22:28:09.000-07:00","identifier":"question11","endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "answerType" : {
+    "codingFormat" : "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+    "type" : "date-time"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question11",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : "2017-10-16T22:28:09.000-07:00"
+}

--- a/examples/v2/ResultData/AnswerResultObject_11.json
+++ b/examples/v2/ResultData/AnswerResultObject_11.json
@@ -1,1 +1,11 @@
-{"startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"codingFormat":"HH:mm:ss.SSS","type":"time"},"type":"answer","value":"22:28:00.000","endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question12"}
+{
+  "answerType" : {
+    "codingFormat" : "HH:mm:ss.SSS",
+    "type" : "time"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question12",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : "22:28:00.000"
+}

--- a/examples/v2/ResultData/AnswerResultObject_12.json
+++ b/examples/v2/ResultData/AnswerResultObject_12.json
@@ -1,1 +1,15 @@
-{"type":"answer","value":75,"endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"displayUnits":["hour","minute"],"type":"duration","significantDigits":0},"identifier":"question13"}
+{
+  "answerType" : {
+    "displayUnits" : [
+      "hour",
+      "minute"
+    ],
+    "significantDigits" : 0,
+    "type" : "duration"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question13",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : 75
+}

--- a/examples/v2/ResultData/AnswerResultObject_13.json
+++ b/examples/v2/ResultData/AnswerResultObject_13.json
@@ -1,1 +1,11 @@
-{"endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question14","type":"answer","answerType":{"unit":"cm","type":"measurement"},"value":170.19999999999999}
+{
+  "answerType" : {
+    "type" : "measurement",
+    "unit" : "cm"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question14",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : 170.19999999999999
+}

--- a/examples/v2/ResultData/AnswerResultObject_2.json
+++ b/examples/v2/ResultData/AnswerResultObject_2.json
@@ -1,1 +1,10 @@
-{"startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"number"},"type":"answer","endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question3","value":3.1400000000000001}
+{
+  "answerType" : {
+    "type" : "number"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question3",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : 3.1400000000000001
+}

--- a/examples/v2/ResultData/AnswerResultObject_3.json
+++ b/examples/v2/ResultData/AnswerResultObject_3.json
@@ -1,1 +1,12 @@
-{"endDate":"2017-10-16T22:28:09.000-07:00","value":{"foo":"ba"},"type":"answer","answerType":{"type":"object"},"identifier":"question4","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "answerType" : {
+    "type" : "object"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question4",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : {
+    "foo" : "ba"
+  }
+}

--- a/examples/v2/ResultData/AnswerResultObject_4.json
+++ b/examples/v2/ResultData/AnswerResultObject_4.json
@@ -1,1 +1,10 @@
-{"endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question5","startDate":"2017-10-16T22:28:09.000-07:00","value":"foo","answerType":{"type":"string"},"type":"answer"}
+{
+  "answerType" : {
+    "type" : "string"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question5",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : "foo"
+}

--- a/examples/v2/ResultData/AnswerResultObject_5.json
+++ b/examples/v2/ResultData/AnswerResultObject_5.json
@@ -1,1 +1,14 @@
-{"answerType":{"baseType":"number","type":"array"},"value":[3.2000000000000002,5.0999999999999996],"startDate":"2017-10-16T22:28:09.000-07:00","type":"answer","endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question6"}
+{
+  "answerType" : {
+    "baseType" : "number",
+    "type" : "array"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question6",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : [
+    3.2000000000000002,
+    5.0999999999999996
+  ]
+}

--- a/examples/v2/ResultData/AnswerResultObject_6.json
+++ b/examples/v2/ResultData/AnswerResultObject_6.json
@@ -1,1 +1,14 @@
-{"value":[1,5],"endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question7","startDate":"2017-10-16T22:28:09.000-07:00","type":"answer","answerType":{"baseType":"integer","type":"array"}}
+{
+  "answerType" : {
+    "baseType" : "integer",
+    "type" : "array"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question7",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : [
+    1,
+    5
+  ]
+}

--- a/examples/v2/ResultData/AnswerResultObject_7.json
+++ b/examples/v2/ResultData/AnswerResultObject_7.json
@@ -1,1 +1,15 @@
-{"answerType":{"type":"array","baseType":"string"},"identifier":"question8","type":"answer","endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00","value":["foo","ba","lalala"]}
+{
+  "answerType" : {
+    "baseType" : "string",
+    "type" : "array"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question8",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : [
+    "foo",
+    "ba",
+    "lalala"
+  ]
+}

--- a/examples/v2/ResultData/AnswerResultObject_8.json
+++ b/examples/v2/ResultData/AnswerResultObject_8.json
@@ -1,1 +1,11 @@
-{"endDate":"2017-10-16T22:28:09.000-07:00","value":"2020-04","answerType":{"type":"date-time","codingFormat":"yyyy-MM"},"identifier":"question9","type":"answer","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "answerType" : {
+    "codingFormat" : "yyyy-MM",
+    "type" : "date-time"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question9",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : "2020-04"
+}

--- a/examples/v2/ResultData/AnswerResultObject_9.json
+++ b/examples/v2/ResultData/AnswerResultObject_9.json
@@ -1,1 +1,11 @@
-{"endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","answerType":{"codingFormat":"HH:mm","type":"date-time"},"identifier":"question10","value":"08:30","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "answerType" : {
+    "codingFormat" : "HH:mm",
+    "type" : "date-time"
+  },
+  "endDate" : "2017-10-16T22:28:09.000-07:00",
+  "identifier" : "question10",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "answer",
+  "value" : "08:30"
+}

--- a/examples/v2/ResultData/BranchNodeResultObject_0.json
+++ b/examples/v2/ResultData/BranchNodeResultObject_0.json
@@ -1,1 +1,219 @@
-{"asyncResults":[{"endDate":"2017-10-16T22:30:29.000-07:00","startDate":"2017-10-16T22:28:29.000-07:00","contentType":"application\/json","type":"file","identifier":"fileResult","jsonSchema":"file:\/\/temp\/foo.schema.json","relativePath":"\/foo.json","startUptime":1234.567}],"path":[{"identifier":"introduction","direction":"forward"},{"direction":"forward","identifier":"answers"},{"direction":"forward","identifier":"conclusion"}],"type":"section","identifier":"example","endDate":"2017-10-16T22:30:49.000-07:00","stepHistory":[{"startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:29.000-07:00","identifier":"introduction","type":"base"},{"type":"collection","startDate":"2017-10-16T22:28:29.000-07:00","identifier":"answers","endDate":"2017-10-16T22:30:29.000-07:00","children":[{"endDate":"2017-10-16T22:28:09.000-07:00","value":true,"type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"boolean"},"identifier":"question1"},{"value":42,"answerType":{"type":"integer"},"type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question2","endDate":"2017-10-16T22:28:09.000-07:00"},{"value":3.1400000000000001,"identifier":"question3","endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"number"}},{"type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question4","answerType":{"type":"object"},"value":{"foo":"ba"},"endDate":"2017-10-16T22:28:09.000-07:00"},{"value":"foo","identifier":"question5","answerType":{"type":"string"},"type":"answer","endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00"},{"type":"answer","value":[3.2000000000000002,5.0999999999999996],"identifier":"question6","startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"array","baseType":"number"},"endDate":"2017-10-16T22:28:09.000-07:00"},{"answerType":{"baseType":"integer","type":"array"},"endDate":"2017-10-16T22:28:09.000-07:00","value":[1,5],"identifier":"question7","type":"answer","startDate":"2017-10-16T22:28:09.000-07:00"},{"value":["foo","ba","lalala"],"answerType":{"baseType":"string","type":"array"},"identifier":"question8","startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00","type":"answer"},{"endDate":"2017-10-16T22:28:09.000-07:00","answerType":{"codingFormat":"yyyy-MM","type":"date-time"},"startDate":"2017-10-16T22:28:09.000-07:00","type":"answer","identifier":"question9","value":"2020-04"},{"endDate":"2017-10-16T22:28:09.000-07:00","value":"08:30","identifier":"question10","type":"answer","answerType":{"type":"date-time","codingFormat":"HH:mm"},"startDate":"2017-10-16T22:28:09.000-07:00"},{"endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","value":"2017-10-16T22:28:09.000-07:00","answerType":{"codingFormat":"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ","type":"date-time"},"startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question11"},{"value":"22:28:00.000","identifier":"question12","answerType":{"codingFormat":"HH:mm:ss.SSS","type":"time"},"endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00","type":"answer"},{"value":75,"type":"answer","endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question13","startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"duration","significantDigits":0,"displayUnits":["hour","minute"]}},{"answerType":{"unit":"cm","type":"measurement"},"endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","identifier":"question14","value":170.19999999999999,"startDate":"2017-10-16T22:28:09.000-07:00"}]},{"startDate":"2017-10-16T22:30:29.000-07:00","endDate":"2017-10-16T22:30:49.000-07:00","type":"base","identifier":"conclusion"}],"startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "asyncResults" : [
+    {
+      "contentType" : "application/json",
+      "endDate" : "2017-10-16T22:30:29.000-07:00",
+      "identifier" : "fileResult",
+      "jsonSchema" : "file://temp/foo.schema.json",
+      "relativePath" : "/foo.json",
+      "startDate" : "2017-10-16T22:28:29.000-07:00",
+      "startUptime" : 1234.567,
+      "type" : "file"
+    }
+  ],
+  "endDate" : "2017-10-16T22:30:49.000-07:00",
+  "identifier" : "example",
+  "path" : [
+    {
+      "direction" : "forward",
+      "identifier" : "introduction"
+    },
+    {
+      "direction" : "forward",
+      "identifier" : "answers"
+    },
+    {
+      "direction" : "forward",
+      "identifier" : "conclusion"
+    }
+  ],
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "stepHistory" : [
+    {
+      "endDate" : "2017-10-16T22:28:29.000-07:00",
+      "identifier" : "introduction",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "base"
+    },
+    {
+      "children" : [
+        {
+          "answerType" : {
+            "type" : "boolean"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question1",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : true
+        },
+        {
+          "answerType" : {
+            "type" : "integer"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question2",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 42
+        },
+        {
+          "answerType" : {
+            "type" : "number"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question3",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 3.1400000000000001
+        },
+        {
+          "answerType" : {
+            "type" : "object"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question4",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : {
+            "foo" : "ba"
+          }
+        },
+        {
+          "answerType" : {
+            "type" : "string"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question5",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "foo"
+        },
+        {
+          "answerType" : {
+            "baseType" : "number",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question6",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            3.2000000000000002,
+            5.0999999999999996
+          ]
+        },
+        {
+          "answerType" : {
+            "baseType" : "integer",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question7",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            1,
+            5
+          ]
+        },
+        {
+          "answerType" : {
+            "baseType" : "string",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question8",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            "foo",
+            "ba",
+            "lalala"
+          ]
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "yyyy-MM",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question9",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "2020-04"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "HH:mm",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question10",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "08:30"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question11",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "2017-10-16T22:28:09.000-07:00"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "HH:mm:ss.SSS",
+            "type" : "time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question12",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "22:28:00.000"
+        },
+        {
+          "answerType" : {
+            "displayUnits" : [
+              "hour",
+              "minute"
+            ],
+            "significantDigits" : 0,
+            "type" : "duration"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question13",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 75
+        },
+        {
+          "answerType" : {
+            "type" : "measurement",
+            "unit" : "cm"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question14",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 170.19999999999999
+        }
+      ],
+      "endDate" : "2017-10-16T22:30:29.000-07:00",
+      "identifier" : "answers",
+      "startDate" : "2017-10-16T22:28:29.000-07:00",
+      "type" : "collection"
+    },
+    {
+      "endDate" : "2017-10-16T22:30:49.000-07:00",
+      "identifier" : "conclusion",
+      "startDate" : "2017-10-16T22:30:29.000-07:00",
+      "type" : "base"
+    }
+  ],
+  "type" : "section"
+}

--- a/examples/v2/ResultData/CollectionResultObject_0.json
+++ b/examples/v2/ResultData/CollectionResultObject_0.json
@@ -1,1 +1,173 @@
-{"identifier":"answers","children":[{"type":"answer","answerType":{"type":"boolean"},"identifier":"question1","endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00","value":true},{"identifier":"question2","type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","value":42,"answerType":{"type":"integer"},"endDate":"2017-10-16T22:28:09.000-07:00"},{"endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","identifier":"question3","startDate":"2017-10-16T22:28:09.000-07:00","value":3.1400000000000001,"answerType":{"type":"number"}},{"type":"answer","identifier":"question4","startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"object"},"value":{"foo":"ba"}},{"type":"answer","identifier":"question5","startDate":"2017-10-16T22:28:09.000-07:00","value":"foo","endDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"string"}},{"startDate":"2017-10-16T22:28:09.000-07:00","answerType":{"type":"array","baseType":"number"},"type":"answer","value":[3.2000000000000002,5.0999999999999996],"endDate":"2017-10-16T22:28:09.000-07:00","identifier":"question6"},{"answerType":{"type":"array","baseType":"integer"},"type":"answer","startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question7","value":[1,5],"endDate":"2017-10-16T22:28:09.000-07:00"},{"identifier":"question8","answerType":{"type":"array","baseType":"string"},"startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00","type":"answer","value":["foo","ba","lalala"]},{"type":"answer","answerType":{"codingFormat":"yyyy-MM","type":"date-time"},"identifier":"question9","value":"2020-04","endDate":"2017-10-16T22:28:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00"},{"value":"08:30","startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00","answerType":{"codingFormat":"HH:mm","type":"date-time"},"type":"answer","identifier":"question10"},{"type":"answer","identifier":"question11","endDate":"2017-10-16T22:28:09.000-07:00","answerType":{"codingFormat":"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ","type":"date-time"},"startDate":"2017-10-16T22:28:09.000-07:00","value":"2017-10-16T22:28:09.000-07:00"},{"answerType":{"type":"time","codingFormat":"HH:mm:ss.SSS"},"type":"answer","value":"22:28:00.000","identifier":"question12","startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00"},{"answerType":{"displayUnits":["hour","minute"],"type":"duration","significantDigits":0},"value":75,"startDate":"2017-10-16T22:28:09.000-07:00","identifier":"question13","type":"answer","endDate":"2017-10-16T22:28:09.000-07:00"},{"value":170.19999999999999,"answerType":{"type":"measurement","unit":"cm"},"type":"answer","identifier":"question14","startDate":"2017-10-16T22:28:09.000-07:00","endDate":"2017-10-16T22:28:09.000-07:00"}],"endDate":"2017-10-16T22:33:09.000-07:00","type":"collection","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "children" : [
+    {
+      "answerType" : {
+        "type" : "boolean"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question1",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : true
+    },
+    {
+      "answerType" : {
+        "type" : "integer"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question2",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : 42
+    },
+    {
+      "answerType" : {
+        "type" : "number"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question3",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : 3.1400000000000001
+    },
+    {
+      "answerType" : {
+        "type" : "object"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question4",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : {
+        "foo" : "ba"
+      }
+    },
+    {
+      "answerType" : {
+        "type" : "string"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question5",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : "foo"
+    },
+    {
+      "answerType" : {
+        "baseType" : "number",
+        "type" : "array"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question6",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : [
+        3.2000000000000002,
+        5.0999999999999996
+      ]
+    },
+    {
+      "answerType" : {
+        "baseType" : "integer",
+        "type" : "array"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question7",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : [
+        1,
+        5
+      ]
+    },
+    {
+      "answerType" : {
+        "baseType" : "string",
+        "type" : "array"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question8",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : [
+        "foo",
+        "ba",
+        "lalala"
+      ]
+    },
+    {
+      "answerType" : {
+        "codingFormat" : "yyyy-MM",
+        "type" : "date-time"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question9",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : "2020-04"
+    },
+    {
+      "answerType" : {
+        "codingFormat" : "HH:mm",
+        "type" : "date-time"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question10",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : "08:30"
+    },
+    {
+      "answerType" : {
+        "codingFormat" : "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+        "type" : "date-time"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question11",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : "2017-10-16T22:28:09.000-07:00"
+    },
+    {
+      "answerType" : {
+        "codingFormat" : "HH:mm:ss.SSS",
+        "type" : "time"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question12",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : "22:28:00.000"
+    },
+    {
+      "answerType" : {
+        "displayUnits" : [
+          "hour",
+          "minute"
+        ],
+        "significantDigits" : 0,
+        "type" : "duration"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question13",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : 75
+    },
+    {
+      "answerType" : {
+        "type" : "measurement",
+        "unit" : "cm"
+      },
+      "endDate" : "2017-10-16T22:28:09.000-07:00",
+      "identifier" : "question14",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "answer",
+      "value" : 170.19999999999999
+    }
+  ],
+  "endDate" : "2017-10-16T22:33:09.000-07:00",
+  "identifier" : "answers",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "collection"
+}

--- a/examples/v2/ResultData/ErrorResultObject_0.json
+++ b/examples/v2/ResultData/ErrorResultObject_0.json
@@ -1,1 +1,8 @@
-{"errorDomain":"ExampleDomain","startDate":"2022-06-14T11:29:59.943-07:00","type":"error","errorCode":1,"errorDescription":"example error","identifier":"errorResult"}
+{
+  "errorCode" : 1,
+  "errorDescription" : "example error",
+  "errorDomain" : "ExampleDomain",
+  "identifier" : "errorResult",
+  "startDate" : "2023-04-18T16:11:54.235-07:00",
+  "type" : "error"
+}

--- a/examples/v2/ResultData/FileResultObject_0.json
+++ b/examples/v2/ResultData/FileResultObject_0.json
@@ -1,1 +1,10 @@
-{"relativePath":"\/foo.json","jsonSchema":"file:\/\/temp\/foo.schema.json","endDate":"2017-10-16T22:33:09.000-07:00","identifier":"fileResult","startDate":"2017-10-16T22:28:09.000-07:00","type":"file","startUptime":1234.567,"contentType":"application\/json"}
+{
+  "contentType" : "application/json",
+  "endDate" : "2017-10-16T22:33:09.000-07:00",
+  "identifier" : "fileResult",
+  "jsonSchema" : "file://temp/foo.schema.json",
+  "relativePath" : "/foo.json",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "startUptime" : 1234.567,
+  "type" : "file"
+}

--- a/examples/v2/ResultData/ResultObject_0.json
+++ b/examples/v2/ResultData/ResultObject_0.json
@@ -1,1 +1,6 @@
-{"identifier":"step1","type":"base","endDate":"2017-10-16T22:33:09.000-07:00","startDate":"2017-10-16T22:28:09.000-07:00"}
+{
+  "endDate" : "2017-10-16T22:33:09.000-07:00",
+  "identifier" : "step1",
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "type" : "base"
+}

--- a/examples/v2/TextInputItem/DoubleTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/DoubleTextInputItemObject_0.json
@@ -1,1 +1,3 @@
-{"type":"number"}
+{
+  "type" : "number"
+}

--- a/examples/v2/TextInputItem/DurationTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/DurationTextInputItemObject_0.json
@@ -1,1 +1,3 @@
-{"type":"duration"}
+{
+  "type" : "duration"
+}

--- a/examples/v2/TextInputItem/IntegerTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/IntegerTextInputItemObject_0.json
@@ -1,1 +1,3 @@
-{"type":"integer"}
+{
+  "type" : "integer"
+}

--- a/examples/v2/TextInputItem/StringTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/StringTextInputItemObject_0.json
@@ -1,1 +1,3 @@
-{"type":"string"}
+{
+  "type" : "string"
+}

--- a/examples/v2/TextInputItem/TimeTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/TimeTextInputItemObject_0.json
@@ -1,1 +1,3 @@
-{"type":"time"}
+{
+  "type" : "time"
+}

--- a/examples/v2/TextInputItem/YearTextInputItemObject_0.json
+++ b/examples/v2/TextInputItem/YearTextInputItemObject_0.json
@@ -1,1 +1,4 @@
-{"placeholder":"YYYY","type":"year"}
+{
+  "placeholder" : "YYYY",
+  "type" : "year"
+}

--- a/generator/Package.resolved
+++ b/generator/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
         "state": {
           "branch": null,
-          "revision": "7ee993de078cf08ed7f6a98a751011a7093be31f",
-          "version": "0.7.3"
+          "revision": "0bd38c1530381ee7dd6492c7265304af020de73d",
+          "version": "0.11.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "ca85a1bb5272f428d050d514d72fdea05c95f6fb",
-          "version": "1.4.10"
+          "revision": "78a329aeb640e430a346ebdb45f7655613c3ab56",
+          "version": "2.1.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
         "state": {
           "branch": null,
-          "revision": "9c48602422ff2de9404112b9f2ed98c0a9ca2c44",
-          "version": "1.2.4"
+          "revision": "4a60eae2182fc1b69e205854d4fbad0e9b123a6c",
+          "version": "1.5.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/SharedMobileUI-AppleOS.git",
         "state": {
           "branch": null,
-          "revision": "c16c754cff58d9eb3ec786aa163350538fc74c3d",
-          "version": "0.15.2"
+          "revision": "16b8b57e1b2d2e2746dd8f55ca620f1d25dc8855",
+          "version": "0.19.1"
         }
       }
     ]

--- a/generator/Package.swift
+++ b/generator/Package.swift
@@ -14,10 +14,13 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(name: "AssessmentModel",
                  url: "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
-                 from: "0.7.0"),
+                 from: "0.11.0"),
+        .package(name: "MobilePassiveData",
+                 url: "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
+                 from: "1.5.3"),
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.4.10"),
+                 from: "2.1.1"),
     ],
     targets: [
         

--- a/generator/Sources/generator/main.swift
+++ b/generator/Sources/generator/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 import JsonModel
 import AssessmentModel
+import ResultModel
 
 func buildJson() {
     let factory = GeneratorFactory()
@@ -20,8 +21,9 @@ func buildJson() {
         let doc = JsonDocumentBuilder(factory: factory)
 
         let docs = try doc.buildSchemas()
-        let encoder = factory.createJSONEncoder()
+        let encoder = factory.createJSONEncoder() as! OrderedJSONEncoder
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.shouldOrderKeys = true
 
         try docs.forEach { (doc) in
         
@@ -57,7 +59,7 @@ func buildJson() {
                     try fileManager.createDirectory(at: subdir, withIntermediateDirectories: true, attributes: nil)
                     let filename = "\(className)_\(index).json"
                     let url = subdir.appendingPathComponent(filename)
-                    let exampleJson = try JSONSerialization.data(withJSONObject: example, options: [])
+                    let exampleJson = try JSONSerialization.data(withJSONObject: example, options: [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes])
                     try exampleJson.write(to: url)
                     print(url)
                 }

--- a/schemas/v2/ArchiveMetadata.json
+++ b/schemas/v2/ArchiveMetadata.json
@@ -46,11 +46,10 @@
         "filename",
         "timestamp"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "filename" : "foo.json",
-          "timestamp" : "2022-06-14T11:29:59.915-07:00",
+          "timestamp" : "2023-04-18T16:11:54.228-07:00",
           "contentType" : "application/json",
           "identifier" : "foo",
           "stepPath" : "Bar/foo",
@@ -98,7 +97,7 @@
     {
       "appName" : "???",
       "appVersion" : "???",
-      "deviceInfo" : "Mac Version 12.4 (Build 21F79)",
+      "deviceInfo" : "Mac Version 13.2.1 (Build 22D68)",
       "deviceTypeIdentifier" : "Mac",
       "files" : [
         {

--- a/schemas/v2/AssessmentObject.json
+++ b/schemas/v2/AssessmentObject.json
@@ -45,9 +45,6 @@
           "default" : true
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
           "canResume" : false,
@@ -151,10 +148,10 @@
   ],
   "allOf" : [
     {
-      "$ref" : "Assessment.json"
+      "$ref" : "Node.json"
     },
     {
-      "$ref" : "Node.json"
+      "$ref" : "Assessment.json"
     }
   ],
   "examples" : [

--- a/schemas/v2/AssessmentResultObject.json
+++ b/schemas/v2/AssessmentResultObject.json
@@ -22,15 +22,19 @@
       "title" : "PathMarker",
       "description" : "",
       "properties" : {
+        "identifier" : {
+          "type" : "string",
+          "description" : "The node identifier for this path marker."
+        },
         "direction" : {
           "$ref" : "#/definitions/Direction",
           "description" : "The direction of the path navigation."
         }
       },
       "required" : [
+        "identifier",
         "direction"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "identifier" : "foo",
@@ -40,9 +44,41 @@
     }
   },
   "properties" : {
+    "type" : {
+      "const" : "assessment",
+      "$ref" : "ResultData.json#SerializableResultType"
+    },
+    "identifier" : {
+      "type" : "string"
+    },
+    "startDate" : {
+      "type" : "string",
+      "format" : "date-time"
+    },
+    "endDate" : {
+      "type" : "string",
+      "format" : "date-time"
+    },
     "assessmentIdentifier" : {
       "type" : "string",
       "description" : "An identifier for the assessment model associated with this result. If included, this is intended to match the identifier used by the services that requested running the assessment. This could be a schedule identifier or an identifier in a different namespace than the \"task identifier\" used by the assessment developers to identify their assessments."
+    },
+    "versionString" : {
+      "type" : "string",
+      "description" : "The versioning key used by the developer to version this assessment."
+    },
+    "taskRunUUID" : {
+      "type" : "string",
+      "description" : "A unique identifier for this run of the assessment. This property is defined as readwrite to allow the controller for the task to set this on the ``AssessmentResult`` children included in this run."
+    },
+    "schemaIdentifier" : {
+      "type" : "string",
+      "description" : "An identifier that can be used either by the developer or researcher for custom mapping."
+    },
+    "$schema" : {
+      "type" : "string",
+      "description" : "The json schema URI for this result.",
+      "format" : "uri"
     },
     "stepHistory" : {
       "type" : "array",
@@ -51,10 +87,6 @@
         "$ref" : "ResultData.json"
       }
     },
-    "type" : {
-      "const" : "assessment",
-      "$ref" : "ResultData.json#SerializableResultType"
-    },
     "asyncResults" : {
       "type" : "array",
       "description" : "A list of all the asynchronous results for this task. The list should include uniquely identified results.",
@@ -62,35 +94,12 @@
         "$ref" : "ResultData.json"
       }
     },
-    "identifier" : {
-      "type" : "string"
-    },
-    "versionString" : {
-      "type" : "string",
-      "description" : "The versioning key used by the developer to version this assessment."
-    },
     "path" : {
       "type" : "array",
       "description" : "The path traversed by this branch.",
       "items" : {
         "$ref" : "#/definitions/PathMarker"
       }
-    },
-    "startDate" : {
-      "type" : "string",
-      "format" : "date-time"
-    },
-    "taskRunUUID" : {
-      "type" : "string",
-      "description" : "A unique identifier for this run of the assessment. This property is defined as readwrite to allow the controller for the task to set this on the ``AssessmentResult`` children included in this run."
-    },
-    "endDate" : {
-      "type" : "string",
-      "format" : "date-time"
-    },
-    "schemaIdentifier" : {
-      "type" : "string",
-      "description" : "An identifier that can be used either by the developer or researcher for custom mapping."
     }
   },
   "required" : [
@@ -107,6 +116,12 @@
   ],
   "examples" : [
     {
+      "type" : "assessment",
+      "identifier" : "example",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "endDate" : "2017-10-16T22:30:49.000-07:00",
+      "taskRunUUID" : "17C6DBC8-6F7F-47FF-94E8-56D659A39332",
+      "$schema" : "https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/AssessmentResultObject.json",
       "stepHistory" : [
         {
           "endDate" : "2017-10-16T22:28:29.000-07:00",
@@ -294,7 +309,6 @@
           "type" : "base"
         }
       ],
-      "type" : "assessment",
       "asyncResults" : [
         {
           "contentType" : "application/json",
@@ -307,7 +321,6 @@
           "type" : "file"
         }
       ],
-      "identifier" : "example",
       "path" : [
         {
           "direction" : "forward",
@@ -321,10 +334,7 @@
           "direction" : "forward",
           "identifier" : "conclusion"
         }
-      ],
-      "startDate" : "2017-10-16T22:28:09.000-07:00",
-      "taskRunUUID" : "6112F03C-D52A-42F7-8634-74403DA59554",
-      "endDate" : "2017-10-16T22:30:49.000-07:00"
+      ]
     }
   ]
 }

--- a/schemas/v2/AsyncActionConfiguration.json
+++ b/schemas/v2/AsyncActionConfiguration.json
@@ -243,7 +243,6 @@
         "key",
         "provider"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "identifier" : "weather",

--- a/schemas/v2/AudioLevelRecord.json
+++ b/schemas/v2/AudioLevelRecord.json
@@ -42,8 +42,6 @@
         "description" : "The unit of measurement for the decibel levels."
       }
     },
-    "required" : [
-    ],
     "examples" : [
       {
         "uptime" : 1234567,

--- a/schemas/v2/DistanceRecord.json
+++ b/schemas/v2/DistanceRecord.json
@@ -77,14 +77,13 @@
     "required" : [
       "stepPath"
     ],
-    "additionalProperties" : false,
     "examples" : [
       {
         "uptime" : 99494.629004376795,
         "timestamp" : 52.422324001789093,
         "stepPath" : "Cardio 12MT/run/runDistance",
-        "timestampDate" : "2022-06-14T11:29:59.888-07:00",
-        "timestampUnix" : 1655231399.888211,
+        "timestampDate" : "2023-04-18T15:07:56.105-07:00",
+        "timestampUnix" : 1681855676.104666,
         "horizontalAccuracy" : 6,
         "relativeDistance" : 2.1164507282484935,
         "verticalAccuracy" : 3,

--- a/schemas/v2/ImageInfo.json
+++ b/schemas/v2/ImageInfo.json
@@ -182,7 +182,6 @@
         "width",
         "height"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "width" : 10,
@@ -196,7 +195,26 @@
       "title" : "Name",
       "description" : "",
       "enum" : [
-        "survey"
+        "default",
+        "cognition",
+        "day_to_day",
+        "demographics",
+        "energy",
+        "environment",
+        "excercise",
+        "exit",
+        "finance",
+        "food",
+        "health",
+        "leisure",
+        "medicine",
+        "mental_health",
+        "mood",
+        "pain",
+        "quality_of_life",
+        "social",
+        "screening",
+        "sleep"
       ]
     },
     "SageResourceImage" : {
@@ -230,7 +248,7 @@
       "examples" : [
         {
           "type" : "sageResource",
-          "imageName" : "survey"
+          "imageName" : "default"
         }
       ]
     }

--- a/schemas/v2/MotionRecord.json
+++ b/schemas/v2/MotionRecord.json
@@ -86,11 +86,9 @@
         "description" : "The `w` component of the vector measurement for this sensor sample. Used by the attitude quaternion."
       }
     },
-    "required" : [
-    ],
     "examples" : [
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "gyro",
@@ -99,7 +97,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "accelerometer",
@@ -108,7 +106,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "magnetometer",
@@ -117,7 +115,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "gravity",
@@ -126,7 +124,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "userAcceleration",
@@ -135,7 +133,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "userAcceleration",
@@ -144,7 +142,7 @@
         "z" : -0.9501953125
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "attitude",
@@ -155,7 +153,7 @@
         "w" : 1
       },
       {
-        "uptime" : 70448.193452805994,
+        "uptime" : 4855323.7011648333,
         "timestamp" : 0,
         "stepPath" : "step1",
         "sensorType" : "magneticField",

--- a/schemas/v2/Node.json
+++ b/schemas/v2/Node.json
@@ -186,6 +186,13 @@
         "image" : {
           "$ref" : "ImageInfo.json",
           "description" : "An image or animation to display with this node."
+        },
+        "spokenInstructions" : {
+          "type" : "object",
+          "description" : "A mapping of a localized spoken instruction to a key where the key is either 'start' or 'end'.",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         }
       },
       "required" : [
@@ -200,6 +207,90 @@
         {
           "type" : "completion",
           "identifier" : "example"
+        }
+      ]
+    },
+    "CountdownStepObject" : {
+      "$id" : "#CountdownStepObject",
+      "type" : "object",
+      "title" : "CountdownStepObject",
+      "description" : "",
+      "properties" : {
+        "type" : {
+          "const" : "countdown",
+          "$ref" : "#/definitions/SerializableNodeType"
+        },
+        "comment" : {
+          "type" : "string",
+          "description" : "A developer-facing comment about this node."
+        },
+        "shouldHideActions" : {
+          "type" : "array",
+          "description" : "A list of buttons that should be hidden even if the default is to show them.",
+          "items" : {
+            "$ref" : "AssessmentObject.json#ButtonType"
+          }
+        },
+        "actions" : {
+          "type" : "object",
+          "description" : "A mapping of button action to content information for that button.",
+          "additionalProperties" : {
+            "$ref" : "ButtonActionInfo.json"
+          }
+        },
+        "nextStepIdentifier" : {
+          "$ref" : "ButtonActionInfo.json#NavigationIdentifier",
+          "description" : "Used in direct navigation to allow the node to indicate that the navigator should jump to the given node identifier."
+        },
+        "webConfig" : {
+          "description" : "A blob of JSON that can be used by a web-based survey building tool."
+        },
+        "title" : {
+          "type" : "string",
+          "description" : "The primary text to display for the node in a localized string. The UI should display this using a larger font."
+        },
+        "subtitle" : {
+          "type" : "string",
+          "description" : "A subtitle to display for the node in a localized string."
+        },
+        "detail" : {
+          "type" : "string",
+          "description" : "Detail text to display for the node in a localized string."
+        },
+        "image" : {
+          "$ref" : "ImageInfo.json",
+          "description" : "An image or animation to display with this node."
+        },
+        "spokenInstructions" : {
+          "type" : "object",
+          "description" : "A mapping of a localized spoken instruction to a key where the key is either 'start' or 'end'.",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "duration" : {
+          "type" : "number",
+          "description" : "The duration of the coundown."
+        },
+        "fullInstructionsOnly" : {
+          "type" : "boolean",
+          "description" : "Should this instruction step be displayed when displaying full instructions only?",
+          "default" : false
+        }
+      },
+      "required" : [
+        "type"
+      ],
+      "allOf" : [
+        {
+          "$ref" : "#"
+        }
+      ],
+      "examples" : [
+        {
+          "type" : "countdown",
+          "identifier" : "example",
+          "duration" : 3
         }
       ]
     },
@@ -254,17 +345,17 @@
           "$ref" : "ImageInfo.json",
           "description" : "An image or animation to display with this node."
         },
-        "fullInstructionsOnly" : {
-          "type" : "boolean",
-          "description" : "Should this instruction step be displayed when displaying full instructions only?",
-          "default" : false
-        },
         "spokenInstructions" : {
           "type" : "object",
           "description" : "A mapping of a localized spoken instruction to a key where the key is either 'start' or 'end'.",
           "additionalProperties" : {
             "type" : "string"
           }
+        },
+        "fullInstructionsOnly" : {
+          "type" : "boolean",
+          "description" : "Should this instruction step be displayed when displaying full instructions only?",
+          "default" : false
         }
       },
       "required" : [
@@ -311,7 +402,6 @@
       "required" : [
         "text"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "value" : 1,
@@ -340,12 +430,37 @@
       "required" : [
         "skipToIdentifier"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "matchingAnswer" : "Stop",
           "skipToIdentifier" : "exit",
           "ruleOperator" : "eq"
+        }
+      ]
+    },
+    "OverviewIcon" : {
+      "$id" : "#OverviewIcon",
+      "type" : "object",
+      "title" : "OverviewIcon",
+      "description" : "",
+      "properties" : {
+        "icon" : {
+          "type" : "string",
+          "description" : "The name of the icon."
+        },
+        "title" : {
+          "type" : "string",
+          "description" : "The localized title for the icon."
+        }
+      },
+      "required" : [
+        "icon",
+        "title"
+      ],
+      "examples" : [
+        {
+          "icon" : "hello",
+          "title" : "Hello, World!"
         }
       ]
     },
@@ -406,6 +521,13 @@
           "items" : {
             "$ref" : "#/definitions/PermissionInfoObject"
           }
+        },
+        "icons" : {
+          "type" : "array",
+          "description" : "A list of icons associated with this overview screen.",
+          "items" : {
+            "$ref" : "#/definitions/OverviewIcon"
+          }
         }
       },
       "required" : [
@@ -450,7 +572,6 @@
       "required" : [
         "permissionType"
       ],
-      "additionalProperties" : false,
       "examples" : [
         {
           "permissionType" : "motion"
@@ -508,17 +629,17 @@
           "$ref" : "ImageInfo.json",
           "description" : "An image or animation to display with this node."
         },
-        "fullInstructionsOnly" : {
-          "type" : "boolean",
-          "description" : "Should this instruction step be displayed when displaying full instructions only?",
-          "default" : false
-        },
         "spokenInstructions" : {
           "type" : "object",
           "description" : "A mapping of a localized spoken instruction to a key where the key is either 'start' or 'end'.",
           "additionalProperties" : {
             "type" : "string"
           }
+        },
+        "fullInstructionsOnly" : {
+          "type" : "boolean",
+          "description" : "Should this instruction step be displayed when displaying full instructions only?",
+          "default" : false
         },
         "permissionType" : {
           "$ref" : "AsyncActionConfiguration.json#AsyncActionType",
@@ -561,12 +682,12 @@
       "title" : "QuestionUIHint",
       "description" : "",
       "examples" : [
-        "textfield",
-        "radioButton",
         "picker",
-        "likert",
         "multipleLine",
         "slider",
+        "textfield",
+        "radioButton",
+        "likert",
         "checkbox"
       ]
     },
@@ -670,12 +791,13 @@
       "examples" : [
         "assessment",
         "section",
-        "overview",
+        "completion",
         "instruction",
-        "permission",
+        "overview",
         "choiceQuestion",
         "simpleQuestion",
-        "completion"
+        "countdown",
+        "permission"
       ]
     },
     "SimpleQuestionStepObject" : {

--- a/schemas/v2/ResultData.json
+++ b/schemas/v2/ResultData.json
@@ -212,16 +212,16 @@
       "title" : "BranchNodeResultObject",
       "description" : "",
       "properties" : {
+        "type" : {
+          "const" : "section",
+          "$ref" : "#/definitions/SerializableResultType"
+        },
         "stepHistory" : {
           "type" : "array",
           "description" : "The ``stepHistory`` includes the history of the node results that were traversed as a part of running an assessment.",
           "items" : {
             "$ref" : "#"
           }
-        },
-        "type" : {
-          "const" : "section",
-          "$ref" : "#/definitions/SerializableResultType"
         },
         "asyncResults" : {
           "type" : "array",
@@ -249,6 +249,10 @@
       ],
       "examples" : [
         {
+          "type" : "section",
+          "identifier" : "example",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "endDate" : "2017-10-16T22:30:49.000-07:00",
           "stepHistory" : [
             {
               "endDate" : "2017-10-16T22:28:29.000-07:00",
@@ -436,7 +440,6 @@
               "type" : "base"
             }
           ],
-          "type" : "section",
           "asyncResults" : [
             {
               "contentType" : "application/json",
@@ -449,7 +452,6 @@
               "type" : "file"
             }
           ],
-          "identifier" : "example",
           "path" : [
             {
               "direction" : "forward",
@@ -463,9 +465,7 @@
               "direction" : "forward",
               "identifier" : "conclusion"
             }
-          ],
-          "startDate" : "2017-10-16T22:28:09.000-07:00",
-          "endDate" : "2017-10-16T22:30:49.000-07:00"
+          ]
         }
       ]
     },
@@ -475,16 +475,16 @@
       "title" : "CollectionResultObject",
       "description" : "",
       "properties" : {
+        "type" : {
+          "const" : "collection",
+          "$ref" : "#/definitions/SerializableResultType"
+        },
         "children" : {
           "type" : "array",
           "description" : "The list of input results associated with this step or recorder.",
           "items" : {
             "$ref" : "#"
           }
-        },
-        "type" : {
-          "const" : "collection",
-          "$ref" : "#/definitions/SerializableResultType"
         }
       },
       "required" : [
@@ -498,6 +498,10 @@
       ],
       "examples" : [
         {
+          "type" : "collection",
+          "identifier" : "answers",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "endDate" : "2017-10-16T22:33:09.000-07:00",
           "children" : [
             {
               "answerType" : {
@@ -664,11 +668,7 @@
               "type" : "answer",
               "value" : 170.19999999999999
             }
-          ],
-          "type" : "collection",
-          "identifier" : "answers",
-          "startDate" : "2017-10-16T22:28:09.000-07:00",
-          "endDate" : "2017-10-16T22:33:09.000-07:00"
+          ]
         }
       ]
     },
@@ -710,7 +710,7 @@
         {
           "type" : "error",
           "identifier" : "errorResult",
-          "startDate" : "2022-06-14T11:29:59.943-07:00",
+          "startDate" : "2023-04-18T15:07:56.119-07:00",
           "errorDescription" : "example error",
           "errorDomain" : "ExampleDomain",
           "errorCode" : 1
@@ -777,9 +777,6 @@
           "$ref" : "#/definitions/SerializableResultType"
         }
       },
-      "required" : [
-
-      ],
       "allOf" : [
         {
           "$ref" : "#"
@@ -816,7 +813,7 @@
     },
     "identifier" : {
       "type" : "string",
-      "description" : "The identifier associated with the task, step, or asynchronous action."
+      "description" : "The identifier for the result."
     },
     "startDate" : {
       "type" : "string",

--- a/schemas/v2/TextInputItem.json
+++ b/schemas/v2/TextInputItem.json
@@ -45,9 +45,6 @@
           "type" : "string"
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
 
@@ -163,9 +160,6 @@
           "type" : "string"
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
 
@@ -234,9 +228,6 @@
           "$ref" : "#/definitions/KeyboardType"
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
 
@@ -421,9 +412,6 @@
           "format" : "time"
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
 
@@ -497,9 +485,6 @@
           "type" : "string"
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
 

--- a/schemas/v2/WeatherResult.json
+++ b/schemas/v2/WeatherResult.json
@@ -11,19 +11,15 @@
       "title" : "AirQualityServiceResult",
       "description" : "",
       "properties" : {
-        "type" : {
-          "const" : "airQuality",
-          "$ref" : "#/definitions/WeatherServiceType"
-        },
         "identifier" : {
           "type" : "string"
+        },
+        "provider" : {
+          "$ref" : "#/definitions/WeatherServiceProviderName"
         },
         "startDate" : {
           "type" : "string",
           "format" : "date-time"
-        },
-        "provider" : {
-          "$ref" : "#/definitions/WeatherServiceProviderName"
         },
         "aqi" : {
           "type" : "number",
@@ -35,15 +31,14 @@
       },
       "required" : [
         "identifier",
-        "startDate",
-        "provider"
+        "provider",
+        "startDate"
       ],
       "examples" : [
         {
-          "type" : "airQuality",
           "identifier" : "airQuality",
           "provider" : "airNow",
-          "startDate" : "2022-06-14T11:29:59.897-07:00",
+          "startDate" : "2023-04-18T16:11:54.220-07:00",
           "aqi" : 2,
           "category" : {
             "name" : "Moderate",
@@ -91,9 +86,6 @@
           "description" : "Precipitation in the past 3 hours."
         }
       },
-      "required" : [
-
-      ],
       "examples" : [
         {
           "pastHour" : 5,
@@ -117,19 +109,16 @@
       "title" : "WeatherServiceResult",
       "description" : "",
       "properties" : {
-        "type" : {
-          "const" : "weather",
-          "$ref" : "#/definitions/WeatherServiceType"
-        },
         "identifier" : {
-          "type" : "string"
+          "type" : "string",
+          "description" : "Result identifier"
+        },
+        "provider" : {
+          "$ref" : "#/definitions/WeatherServiceProviderName"
         },
         "startDate" : {
           "type" : "string",
           "format" : "date-time"
-        },
-        "provider" : {
-          "$ref" : "#/definitions/WeatherServiceProviderName"
         },
         "temperature" : {
           "type" : "number"
@@ -157,31 +146,19 @@
         }
       },
       "required" : [
-        "type",
         "identifier",
-        "startDate",
-        "provider"
+        "provider",
+        "startDate"
       ],
       "examples" : [
         {
-          "type" : "weather",
           "identifier" : "weather",
           "provider" : "openWeather",
-          "startDate" : "2022-06-14T11:29:59.895-07:00",
+          "startDate" : "2023-04-18T16:11:54.220-07:00",
           "temperature" : 20,
           "humidity" : 0.90000000000000002,
           "clouds" : 0.40000000000000002
         }
-      ]
-    },
-    "WeatherServiceType" : {
-      "$id" : "#WeatherServiceType",
-      "type" : "string",
-      "title" : "WeatherServiceType",
-      "description" : "",
-      "enum" : [
-        "weather",
-        "airQuality"
       ]
     },
     "Wind" : {
@@ -237,6 +214,7 @@
   },
   "required" : [
     "identifier",
+    "type",
     "startDate"
   ],
   "allOf" : [
@@ -248,16 +226,15 @@
     {
       "identifier" : "weather",
       "type" : "weather",
-      "startDate" : "2022-06-14T11:29:59.898-07:00",
-      "endDate" : "2022-06-14T11:29:59.898-07:00",
+      "startDate" : "2023-04-18T16:11:54.221-07:00",
+      "endDate" : "2023-04-18T16:11:54.221-07:00",
       "weather" : {
         "clouds" : 0.40000000000000002,
         "humidity" : 0.90000000000000002,
         "identifier" : "weather",
         "provider" : "openWeather",
-        "startDate" : "2022-06-14T11:29:59.898-07:00",
-        "temperature" : 20,
-        "type" : "weather"
+        "startDate" : "2023-04-18T16:11:54.221-07:00",
+        "temperature" : 20
       },
       "airQuality" : {
         "aqi" : 2,
@@ -267,8 +244,7 @@
         },
         "identifier" : "airQuality",
         "provider" : "airNow",
-        "startDate" : "2022-06-14T11:29:59.898-07:00",
-        "type" : "airQuality"
+        "startDate" : "2023-04-18T16:11:54.221-07:00"
       }
     }
   ]


### PR DESCRIPTION
There's some additions to the `Node` schema to include the countdown and some keys we needed for MotorControl assessments. I also updated the package and generated the examples with the keys sorted and pretty printed (to make it easier next time to check for any differences). Finally, I found that the WeatherResult has the "type" defined for some objects that do not include that field in the Kotlin serialized implementation.