### PR TITLE
Add examples from the roots and validate using GitHub action

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,6 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Validate JSON ArchiveMetadata
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/ArchiveMetadata.json
+          INPUT_JSONS: //examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
+      - name: Validate JSON AssessmentObject
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/AssessmentObject.json
+          INPUT_JSONS: //examples/v2/AssessmentObject/AssessmentObject_0.json
+      - name: Validate JSON AssessmentResultObject
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/AssessmentResultObject.json
+          INPUT_JSONS: //examples/v2/AssessmentResultObject/AssessmentResultObject_0.json
       - name: Validate JSON AudioLevelRecord
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
@@ -22,21 +37,6 @@ jobs:
         env:
           INPUT_SCHEMA: //schemas/v2/MotionRecord.json
           INPUT_JSONS: //examples/v2/MotionRecord/MotionRecord_0.json
-      - name: Validate JSON AssessmentObject
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: //schemas/v2/AssessmentObject.json
-          INPUT_JSONS: //examples/v2/AssessmentObject/AssessmentObject_0.json
-      - name: Validate JSON AssessmentResultObject
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: //schemas/v2/AssessmentResultObject.json
-          INPUT_JSONS: //examples/v2/AssessmentResultObject/AssessmentResultObject_0.json
-      - name: Validate JSON ArchiveMetadata
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: //schemas/v2/ArchiveMetadata.json
-          INPUT_JSONS: //examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
       - name: Validate JSON TappingResultObject
         uses: docker://orrosenblatt/validate-json-action:latest
         env:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,8 +7,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Validate JSON
+      - name: Validate JSON AudioLevelRecord
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
-          INPUT_SCHEMA: /schemas/v2/ArchiveMetadata.json
-          INPUT_JSONS: /examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
+          INPUT_SCHEMA: //schemas/v2/AudioLevelRecord.json
+          INPUT_JSONS: //examples/v2/AudioLevelRecord/AudioLevelRecord_0.json
+      - name: Validate JSON DistanceRecord
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/DistanceRecord.json
+          INPUT_JSONS: //examples/v2/DistanceRecord/DistanceRecord_0.json
+      - name: Validate JSON MotionRecord
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/MotionRecord.json
+          INPUT_JSONS: //examples/v2/MotionRecord/MotionRecord_0.json
+      - name: Validate JSON WeatherResult
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/WeatherResult.json
+          INPUT_JSONS: //examples/v2/WeatherResult/WeatherResult_0.json
+      - name: Validate JSON AssessmentObject
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/AssessmentObject.json
+          INPUT_JSONS: //examples/v2/AssessmentObject/AssessmentObject_0.json
+      - name: Validate JSON AssessmentResultObject
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/AssessmentResultObject.json
+          INPUT_JSONS: //examples/v2/AssessmentResultObject/AssessmentResultObject_0.json
+      - name: Validate JSON ArchiveMetadata
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/ArchiveMetadata.json
+          INPUT_JSONS: //examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
+      - name: Validate JSON TappingResultObject
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/TappingResultObject.json
+          INPUT_JSONS: //examples/v2/TappingResultObject/TappingResultObject_0.json

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,14 @@
+name: Validate JSONs
+
+on: [pull_request]
+
+jobs:
+  verify-json-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate JSON
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: /schemas/v2/ArchiveMetadata.json
+          INPUT_JSONS: /examples/v2/ArchiveMetadata/ArchiveMetadata_0.json

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -22,11 +22,6 @@ jobs:
         env:
           INPUT_SCHEMA: //schemas/v2/MotionRecord.json
           INPUT_JSONS: //examples/v2/MotionRecord/MotionRecord_0.json
-      - name: Validate JSON WeatherResult
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: //schemas/v2/WeatherResult.json
-          INPUT_JSONS: //examples/v2/WeatherResult/WeatherResult_0.json
       - name: Validate JSON AssessmentObject
         uses: docker://orrosenblatt/validate-json-action:latest
         env:
@@ -47,3 +42,8 @@ jobs:
         env:
           INPUT_SCHEMA: //schemas/v2/TappingResultObject.json
           INPUT_JSONS: //examples/v2/TappingResultObject/TappingResultObject_0.json
+      - name: Validate JSON WeatherResult
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: //schemas/v2/WeatherResult.json
+          INPUT_JSONS: //examples/v2/WeatherResult/WeatherResult_0.json

--- a/examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
+++ b/examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
@@ -1,0 +1,19 @@
+{
+  "appName" : "???",
+  "appVersion" : "???",
+  "deviceInfo" : "Mac Version 13.3.1 (a) (Build 22E772610a)",
+  "deviceTypeIdentifier" : "Mac",
+  "files" : [
+    {
+      "contentType" : "application/json",
+      "filename" : "foo.json",
+      "identifier" : "foo",
+      "jsonSchema" : "https://example.com/foo.json",
+      "metadata" : {
+        "foo" : "baroo"
+      },
+      "stepPath" : "Goo/foo",
+      "timestamp" : "2017-10-16T22:28:09.000-07:00"
+    }
+  ]
+}

--- a/examples/v2/AssessmentObject/AssessmentObject_0.json
+++ b/examples/v2/AssessmentObject/AssessmentObject_0.json
@@ -1,0 +1,15 @@
+{
+  "$schema" : "https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/AssessmentObject.json",
+  "identifier" : "assessment",
+  "steps" : [
+    {
+      "identifier" : "favoriteColor",
+      "inputItem" : {
+        "type" : "string"
+      },
+      "title" : "What is your favorite color",
+      "type" : "simpleQuestion"
+    }
+  ],
+  "type" : "assessment"
+}

--- a/examples/v2/AssessmentResultObject/AssessmentResultObject_0.json
+++ b/examples/v2/AssessmentResultObject/AssessmentResultObject_0.json
@@ -1,0 +1,221 @@
+{
+  "$schema" : "https://sage-bionetworks.github.io/mobile-client-json/schemas/v2/AssessmentResultObject.json",
+  "asyncResults" : [
+    {
+      "contentType" : "application/json",
+      "endDate" : "2017-10-16T22:30:29.000-07:00",
+      "identifier" : "fileResult",
+      "jsonSchema" : "file://temp/foo.schema.json",
+      "relativePath" : "/foo.json",
+      "startDate" : "2017-10-16T22:28:29.000-07:00",
+      "startUptime" : 1234.567,
+      "type" : "file"
+    }
+  ],
+  "endDate" : "2017-10-16T22:30:49.000-07:00",
+  "identifier" : "example",
+  "path" : [
+    {
+      "direction" : "forward",
+      "identifier" : "introduction"
+    },
+    {
+      "direction" : "forward",
+      "identifier" : "answers"
+    },
+    {
+      "direction" : "forward",
+      "identifier" : "conclusion"
+    }
+  ],
+  "startDate" : "2017-10-16T22:28:09.000-07:00",
+  "stepHistory" : [
+    {
+      "endDate" : "2017-10-16T22:28:29.000-07:00",
+      "identifier" : "introduction",
+      "startDate" : "2017-10-16T22:28:09.000-07:00",
+      "type" : "base"
+    },
+    {
+      "children" : [
+        {
+          "answerType" : {
+            "type" : "boolean"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question1",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : true
+        },
+        {
+          "answerType" : {
+            "type" : "integer"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question2",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 42
+        },
+        {
+          "answerType" : {
+            "type" : "number"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question3",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 3.1400000000000001
+        },
+        {
+          "answerType" : {
+            "type" : "object"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question4",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : {
+            "foo" : "ba"
+          }
+        },
+        {
+          "answerType" : {
+            "type" : "string"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question5",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "foo"
+        },
+        {
+          "answerType" : {
+            "baseType" : "number",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question6",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            3.2000000000000002,
+            5.0999999999999996
+          ]
+        },
+        {
+          "answerType" : {
+            "baseType" : "integer",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question7",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            1,
+            5
+          ]
+        },
+        {
+          "answerType" : {
+            "baseType" : "string",
+            "type" : "array"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question8",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : [
+            "foo",
+            "ba",
+            "lalala"
+          ]
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "yyyy-MM",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question9",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "2020-04"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "HH:mm",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question10",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "08:30"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ",
+            "type" : "date-time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question11",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "2017-10-16T22:28:09.000-07:00"
+        },
+        {
+          "answerType" : {
+            "codingFormat" : "HH:mm:ss.SSS",
+            "type" : "time"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question12",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : "22:28:00.000"
+        },
+        {
+          "answerType" : {
+            "displayUnits" : [
+              "hour",
+              "minute"
+            ],
+            "significantDigits" : 0,
+            "type" : "duration"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question13",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 75
+        },
+        {
+          "answerType" : {
+            "type" : "measurement",
+            "unit" : "cm"
+          },
+          "endDate" : "2017-10-16T22:28:09.000-07:00",
+          "identifier" : "question14",
+          "startDate" : "2017-10-16T22:28:09.000-07:00",
+          "type" : "answer",
+          "value" : 170.19999999999999
+        }
+      ],
+      "endDate" : "2017-10-16T22:30:29.000-07:00",
+      "identifier" : "answers",
+      "startDate" : "2017-10-16T22:28:29.000-07:00",
+      "type" : "collection"
+    },
+    {
+      "endDate" : "2017-10-16T22:30:49.000-07:00",
+      "identifier" : "conclusion",
+      "startDate" : "2017-10-16T22:30:29.000-07:00",
+      "type" : "base"
+    }
+  ],
+  "taskRunUUID" : "955910FD-6C4C-46BC-98A5-580D8D821309",
+  "type" : "assessment"
+}

--- a/examples/v2/AudioLevelRecord/AudioLevelRecord_0.json
+++ b/examples/v2/AudioLevelRecord/AudioLevelRecord_0.json
@@ -1,0 +1,11 @@
+[
+  {
+    "average" : 40.5,
+    "peak" : 56.700000762939453,
+    "stepPath" : "foo/one",
+    "timeInterval" : 1,
+    "timestamp" : 0,
+    "unit" : "dbFS",
+    "uptime" : 1234567
+  }
+]

--- a/examples/v2/DistanceRecord/DistanceRecord_0.json
+++ b/examples/v2/DistanceRecord/DistanceRecord_0.json
@@ -1,0 +1,18 @@
+[
+  {
+    "altitude" : 23.375564581136974,
+    "bearingRadians" : 1.3416965000000001,
+    "course" : 76.873546882061802,
+    "floor" : 3,
+    "horizontalAccuracy" : 6,
+    "relativeDistance" : 2.1164507282484935,
+    "speed" : 1.0289180278778076,
+    "stepPath" : "Cardio 12MT/run/runDistance",
+    "timestamp" : 52.422324001789093,
+    "timestampDate" : "2023-06-05T15:47:38.570-07:00",
+    "timestampUnix" : 1686005258.5697851,
+    "totalDistance" : 63.484948023273581,
+    "uptime" : 99494.629004376795,
+    "verticalAccuracy" : 3
+  }
+]

--- a/examples/v2/MotionRecord/MotionRecord_0.json
+++ b/examples/v2/MotionRecord/MotionRecord_0.json
@@ -1,0 +1,79 @@
+[
+  {
+    "sensorType" : "gyro",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "sensorType" : "accelerometer",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "sensorType" : "magnetometer",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "sensorType" : "gravity",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "sensorType" : "userAcceleration",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "sensorType" : "userAcceleration",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "referenceCoordinate" : "Z-Up",
+    "sensorType" : "attitude",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "w" : 1,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  },
+  {
+    "eventAccuracy" : 4,
+    "heading" : 270,
+    "sensorType" : "magneticField",
+    "stepPath" : "step1",
+    "timestamp" : 0,
+    "uptime" : 2900726.355769,
+    "w" : 1,
+    "x" : 0.064788818359375,
+    "y" : -0.1324615478515625,
+    "z" : -0.9501953125
+  }
+]

--- a/examples/v2/TappingResultObject/TappingResultObject_0.json
+++ b/examples/v2/TappingResultObject/TappingResultObject_0.json
@@ -1,0 +1,23 @@
+{
+  "buttonRectLeft" : "{{60.0, 500.0}, {40.0, 40.0}}",
+  "buttonRectRight" : "{{160.0, 500.0}, {40.0, 40.0}}",
+  "endDate" : "2023-06-05T15:47:38.630-07:00",
+  "identifier" : "tapping",
+  "samples" : [
+    {
+      "buttonIdentifier" : "right",
+      "duration" : 0.20000000000000001,
+      "location" : [
+        60,
+        500
+      ],
+      "stepPath" : "foo",
+      "timestamp" : 0,
+      "uptime" : 1628847
+    }
+  ],
+  "startDate" : "2023-06-05T15:47:38.630-07:00",
+  "tapCount" : 1,
+  "type" : "tapping",
+  "viewSize" : "{320.0, 640.0}"
+}

--- a/examples/v2/WeatherResult/WeatherResult_0.json
+++ b/examples/v2/WeatherResult/WeatherResult_0.json
@@ -1,0 +1,24 @@
+{
+  "airQuality" : {
+    "aqi" : 2,
+    "category" : {
+      "name" : "Moderate",
+      "number" : 2
+    },
+    "identifier" : "airQuality",
+    "provider" : "airNow",
+    "startDate" : "2023-06-05T15:47:38.577-07:00"
+  },
+  "endDate" : "2023-06-05T15:47:38.577-07:00",
+  "identifier" : "weather",
+  "startDate" : "2023-06-05T15:47:38.577-07:00",
+  "type" : "weather",
+  "weather" : {
+    "clouds" : 0.40000000000000002,
+    "humidity" : 0.90000000000000002,
+    "identifier" : "weather",
+    "provider" : "openWeather",
+    "startDate" : "2023-06-05T15:47:38.577-07:00",
+    "temperature" : 20
+  }
+}

--- a/generator/Package.resolved
+++ b/generator/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "78a329aeb640e430a346ebdb45f7655613c3ab56",
-          "version": "2.1.1"
+          "revision": "3274a1192148b9652885d4a6baa50462ae9842b8",
+          "version": "2.2.2"
         }
       },
       {

--- a/generator/Package.swift
+++ b/generator/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/Sage-Bionetworks/AssessmentModelKMM.git",
                  from: "0.11.0"),
         .package(url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "2.1.1"),
+                 from: "2.2.2"),
         .package(url: "https://github.com/Sage-Bionetworks/MotorControl-iOS.git",
                  from: "5.0.0"),
     ],

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,3 +1,12 @@
 # generator
 
-A description of this package.
+This is a semi-automatic generator for creating Json Schema Draft 7 schemas and examples for all our serialized model objects that are not defined by services.
+
+To use:
+1. Open in Xcode
+2. Point at "My Mac" as the target
+3. Push the run button
+4. Copy/paste the files from "mobile-client-json" from the Downloads directory to your github directory.
+5. Open the file ".github/workspaces/validation.yml" and copy/paste from the console to that file.
+6. Check the changes and discard or accept as appropriate
+7. Push your changes and issue a PR 

--- a/generator/Sources/generator/main.swift
+++ b/generator/Sources/generator/main.swift
@@ -89,7 +89,7 @@ class GeneratorFactory : AssessmentFactory {
         }
         
         // print the validation mapping to the console - this can be copy/pasted into .github/workspaces/validation.yml
-        validationMaps.forEach {
+        validationMaps.sorted(by: { $0.className < $1.className }).forEach {
             print($0.yml)
         }
     }

--- a/generator/Sources/generator/main.swift
+++ b/generator/Sources/generator/main.swift
@@ -88,6 +88,7 @@ class GeneratorFactory : AssessmentFactory {
             }
         }
         
+        // print the validation mapping to the console - this can be copy/pasted into .github/workspaces/validation.yml
         validationMaps.forEach {
             print($0.yml)
         }
@@ -131,10 +132,3 @@ class GeneratorFactory : AssessmentFactory {
     }
 }
 
-let ymlTemplate = """
-      - name: Validate JSON
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: /schemas/v2/ArchiveMetadata.json
-          INPUT_JSONS: /examples/v2/ArchiveMetadata/ArchiveMetadata_0.json
-"""

--- a/schemas/v2/AnswerType.json
+++ b/schemas/v2/AnswerType.json
@@ -12,8 +12,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "array",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "array"
         },
         "baseType" : {
           "$ref" : "#/definitions/JsonType",
@@ -55,8 +54,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "boolean",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "boolean"
         }
       },
       "required" : [
@@ -80,8 +78,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "date-time",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "date-time"
         },
         "codingFormat" : {
           "type" : "string",
@@ -118,8 +115,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "duration",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "duration"
         },
         "displayUnits" : {
           "type" : "array",
@@ -159,8 +155,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "integer",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "integer"
         }
       },
       "required" : [
@@ -184,8 +179,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "measurement",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "measurement"
         },
         "unit" : {
           "type" : "string",
@@ -218,8 +212,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "number",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "number"
         },
         "significantDigits" : {
           "type" : "number",
@@ -247,8 +240,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "object",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "object"
         }
       },
       "required" : [
@@ -272,8 +264,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "string",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "string"
         }
       },
       "required" : [
@@ -297,8 +288,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "time",
-          "$ref" : "#/definitions/AnswerTypeType"
+          "const" : "time"
         },
         "codingFormat" : {
           "type" : "string",

--- a/schemas/v2/ArchiveMetadata.json
+++ b/schemas/v2/ArchiveMetadata.json
@@ -14,7 +14,7 @@
         "filename" : {
           "type" : "string",
           "description" : "The filename of the archive object. This should be unique within the manifest.",
-          "format" : "uri-relative"
+          "format" : "uri-reference"
         },
         "timestamp" : {
           "type" : "string",

--- a/schemas/v2/AssessmentObject.json
+++ b/schemas/v2/AssessmentObject.json
@@ -57,8 +57,7 @@
   },
   "properties" : {
     "type" : {
-      "const" : "assessment",
-      "$ref" : "Node.json#SerializableNodeType"
+      "const" : "assessment"
     },
     "identifier" : {
       "type" : "string"

--- a/schemas/v2/AssessmentResultObject.json
+++ b/schemas/v2/AssessmentResultObject.json
@@ -45,8 +45,7 @@
   },
   "properties" : {
     "type" : {
-      "const" : "assessment",
-      "$ref" : "ResultData.json#SerializableResultType"
+      "const" : "assessment"
     },
     "identifier" : {
       "type" : "string"

--- a/schemas/v2/AsyncActionConfiguration.json
+++ b/schemas/v2/AsyncActionConfiguration.json
@@ -24,8 +24,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "microphone",
-          "$ref" : "#/definitions/AsyncActionType"
+          "const" : "microphone"
         },
         "startStepIdentifier" : {
           "type" : "string"
@@ -66,8 +65,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "distance",
-          "$ref" : "#/definitions/AsyncActionType"
+          "const" : "distance"
         },
         "motionStepIdentifier" : {
           "type" : "string"
@@ -107,8 +105,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "motion",
-          "$ref" : "#/definitions/AsyncActionType"
+          "const" : "motion"
         },
         "recorderTypes" : {
           "type" : "array",
@@ -179,8 +176,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "weather",
-          "$ref" : "#/definitions/AsyncActionType"
+          "const" : "weather"
         },
         "startStepIdentifier" : {
           "type" : "string",

--- a/schemas/v2/ButtonActionInfo.json
+++ b/schemas/v2/ButtonActionInfo.json
@@ -12,8 +12,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "default",
-          "$ref" : "#/definitions/ButtonActionInfoType"
+          "const" : "default"
         }
       },
       "required" : [
@@ -52,8 +51,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "navigation",
-          "$ref" : "#/definitions/ButtonActionInfoType"
+          "const" : "navigation"
         },
         "skipToIdentifier" : {
           "$ref" : "#/definitions/NavigationIdentifier",

--- a/schemas/v2/ImageInfo.json
+++ b/schemas/v2/ImageInfo.json
@@ -12,8 +12,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "animated",
-          "$ref" : "#/definitions/ImageInfoType"
+          "const" : "animated"
         },
         "imageNames" : {
           "type" : "array",
@@ -100,8 +99,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "fetchable",
-          "$ref" : "#/definitions/ImageInfoType"
+          "const" : "fetchable"
         },
         "imageName" : {
           "type" : "string",
@@ -224,8 +222,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "sageResource",
-          "$ref" : "#/definitions/ImageInfoType"
+          "const" : "sageResource"
         },
         "imageName" : {
           "$ref" : "#/definitions/Name",

--- a/schemas/v2/Node.json
+++ b/schemas/v2/Node.json
@@ -12,8 +12,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "choiceQuestion",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "choiceQuestion"
         },
         "comment" : {
           "type" : "string",
@@ -143,8 +142,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "completion",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "completion"
         },
         "comment" : {
           "type" : "string",
@@ -217,8 +215,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "countdown",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "countdown"
         },
         "comment" : {
           "type" : "string",
@@ -301,8 +298,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "instruction",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "instruction"
         },
         "comment" : {
           "type" : "string",
@@ -471,8 +467,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "overview",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "overview"
         },
         "comment" : {
           "type" : "string",
@@ -585,8 +580,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "permission",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "permission"
         },
         "comment" : {
           "type" : "string",
@@ -682,13 +676,13 @@
       "title" : "QuestionUIHint",
       "description" : "",
       "examples" : [
-        "picker",
+        "likert",
+        "radioButton",
+        "checkbox",
         "multipleLine",
         "slider",
         "textfield",
-        "radioButton",
-        "likert",
-        "checkbox"
+        "picker"
       ]
     },
     "SectionObject" : {
@@ -698,8 +692,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "section",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "section"
         },
         "comment" : {
           "type" : "string",
@@ -807,8 +800,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "simpleQuestion",
-          "$ref" : "#/definitions/SerializableNodeType"
+          "const" : "simpleQuestion"
         },
         "comment" : {
           "type" : "string",

--- a/schemas/v2/ResultData.json
+++ b/schemas/v2/ResultData.json
@@ -12,8 +12,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "answer",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "answer"
         },
         "answerType" : {
           "$ref" : "AnswerType.json",
@@ -213,8 +212,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "section",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "section"
         },
         "stepHistory" : {
           "type" : "array",
@@ -476,8 +474,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "collection",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "collection"
         },
         "children" : {
           "type" : "array",
@@ -679,8 +676,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "error",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "error"
         },
         "errorDescription" : {
           "type" : "string",
@@ -724,8 +720,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "file",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "file"
         },
         "relativePath" : {
           "type" : "string",
@@ -773,8 +768,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "base",
-          "$ref" : "#/definitions/SerializableResultType"
+          "const" : "base"
         }
       },
       "allOf" : [

--- a/schemas/v2/ResultData.json
+++ b/schemas/v2/ResultData.json
@@ -706,7 +706,7 @@
         {
           "type" : "error",
           "identifier" : "errorResult",
-          "startDate" : "2023-04-18T15:07:56.119-07:00",
+          "startDate" : "2023-06-06T16:14:52.551-07:00",
           "errorDescription" : "example error",
           "errorDomain" : "ExampleDomain",
           "errorCode" : 1
@@ -724,7 +724,8 @@
         },
         "relativePath" : {
           "type" : "string",
-          "description" : "The relative path to the file-based result."
+          "description" : "The relative path to the file-based result.",
+          "format" : "uri-reference"
         },
         "contentType" : {
           "type" : "string",

--- a/schemas/v2/TappingResultObject.json
+++ b/schemas/v2/TappingResultObject.json
@@ -84,8 +84,7 @@
   },
   "properties" : {
     "type" : {
-      "const" : "tapping",
-      "$ref" : "ResultData.json#SerializableResultType"
+      "const" : "tapping"
     },
     "hand" : {
       "$ref" : "#/definitions/HandSelection",

--- a/schemas/v2/TextInputItem.json
+++ b/schemas/v2/TextInputItem.json
@@ -69,8 +69,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "number",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "number"
         },
         "formatOptions" : {
           "$ref" : "#/definitions/DoubleFormatOptions",
@@ -98,8 +97,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "number",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "number"
         },
         "displayUnits" : {
           "type" : "array",
@@ -183,8 +181,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "integer",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "integer"
         },
         "formatOptions" : {
           "$ref" : "#/definitions/IntegerFormatOptions",
@@ -309,8 +306,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "string",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "string"
         },
         "keyboardOptions" : {
           "$ref" : "#/definitions/KeyboardOptionsObject",
@@ -435,8 +431,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "year",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "year"
         },
         "formatOptions" : {
           "$ref" : "#/definitions/TimeFormatOptions",
@@ -506,8 +501,7 @@
       "description" : "",
       "properties" : {
         "type" : {
-          "const" : "year",
-          "$ref" : "#/definitions/TextInputType"
+          "const" : "year"
         },
         "formatOptions" : {
           "$ref" : "#/definitions/YearFormatOptions",

--- a/schemas/v2/WeatherResult.json
+++ b/schemas/v2/WeatherResult.json
@@ -194,8 +194,7 @@
       "type" : "string"
     },
     "type" : {
-      "const" : "weather",
-      "$ref" : "ResultData.json#SerializableResultType"
+      "const" : "weather"
     },
     "startDate" : {
       "type" : "string",


### PR DESCRIPTION
I looked into using a GitHub action to validate the schemas for our root objects. As a part of that exercise, that validation was less forgiving of than Python or Java and I found out that the documentation for Draft 7 has subtly changed (or I misinterpreted it) since I originally wrote this 4 years ago. 

Right now, I am still pointing at the v2 schemas as the definitions and properties have not changed other than fixing "bugs". Specifically:

1. Change "uri-relative" -> "uri-reference"
2. Remove "$ref" from properties that return a "const" - those still have the "$ref" defined on the more permissive interface from which they inherit.
